### PR TITLE
add problem types payloadTooLarge and tooManyFailedRequests

### DIFF
--- a/src/main/asciidoc/changelog.adoc
+++ b/src/main/asciidoc/changelog.adoc
@@ -1,4 +1,6 @@
 == Changelog
+* 202x-xx-xx
+** added two new problem types: <<payloadTooLargeProblem, payloadTooLarge>> and <<tooManyFailedRequestsProblem, tooManyFailedRequests>>
 * 2020-11-04
 ** added: <<remove-collection-items, Remove a selection of items from a collection>> (<<Collection, Collection>>)
 ** updated: status codes made consistent in various locations (<<Collection>>, <<Document>>, <<HTTP Methods>> and <<status-codes>>)

--- a/src/main/asciidoc/errorhandling.adoc
+++ b/src/main/asciidoc/errorhandling.adoc
@@ -186,7 +186,9 @@ include::problems/expiredAccessToken.adoc[leveloffset=3]
 include::problems/missingScope.adoc[leveloffset=3]
 include::problems/missingPermission.adoc[leveloffset=3]
 include::problems/resourceNotFound.adoc[leveloffset=3]
+include::problems/payloadTooLarge.adoc[leveloffset=3]
 include::problems/tooManyRequests.adoc[leveloffset=3]
+include::problems/tooManyFailedRequests.adoc[leveloffset=3]
 
 
 === API specific problem types

--- a/src/main/asciidoc/problems/payloadTooLarge.adoc
+++ b/src/main/asciidoc/problems/payloadTooLarge.adoc
@@ -1,0 +1,29 @@
+[[payloadTooLargeProblem]]
+= Payload Too Large
+:nofooter:
+
+*Status code* 413 Payload Too Large
+
+*Description* The consumer request was refused because its payload is too large.
+The property `limit` contains the maximum payload size expressed in bytes.
+
+```
+POST /attachments
+
+<very large binary attachment>
+```
+
+returns
+
+```
+HTTP/1.1 413 Payload Too Large
+Content-Type: application/problem+json
+
+{
+   "type": "https://www.gcloud.belgium.be/rest/problems/payloadTooLarge",
+   "status": 413,
+   "title": "Payload Too Large",
+   "detail": "Request message must not be larger than 10 MB",
+   "limit": 10485760
+}
+```

--- a/src/main/asciidoc/problems/tooManyFailedRequests.adoc
+++ b/src/main/asciidoc/problems/tooManyFailedRequests.adoc
@@ -1,0 +1,27 @@
+[[tooManyFailedRequestsProblem]]
+= Too Many Failed Requests
+:nofooter:
+
+*Status code* 429 Too Many Requests
+
+*Description* The consumer quota for failed requests resulting was exceeded.
+The property `limit` contains the number of failed requests allowed.
+`retryAfter` indicates the time when the counters will be reset.
+`retryAfterSec` indicates how many seconds the consumer must wait before submitting a new request.
+
+```
+GET /enterprises/123invalidEnterpriseId
+```
+```
+HTTP/1.1 429 Too many requests
+Content-Type: application/problem+json
+{
+   "type": "https://www.gcloud.belgium.be/rest/problems/tooManyFailedRequests",
+   "status": 429,
+   "title": "Too Many Failed Requests",
+   "detail": "No more requests are accepted after previous failures until 2018-08-09T06:56:00Z",
+   "limit": 50,
+   "retryAfter": "2018-08-09T06:56:00Z",
+   "retryAfterSec": 300
+}
+```

--- a/src/main/asciidoc/problems/tooManyRequests.adoc
+++ b/src/main/asciidoc/problems/tooManyRequests.adoc
@@ -3,7 +3,7 @@
 
 *Status code* 429 Too Many Requests
 
-*Description* The consumer quota was passed.
+*Description* The consumer quota was exceeded.
 The property `limit` contains the number of requests allowed.
 `retryAfter` indicates the time when the counters will be reset.
 `retryAfterSec` indicates how many seconds the consumer must wait before resubmitting the request.


### PR DESCRIPTION
two new problem types as discussed in #36 

payloadTooLarge has a limit property expressed in bytes
tooManyFailedRequests follows same structure as tooManyRequests