### PR TITLE
Naming of JSON properties and codes

### DIFF
--- a/guide/src/main/asciidoc/json.adoc
+++ b/guide/src/main/asciidoc/json.adoc
@@ -31,7 +31,7 @@ Properties used from other standards, like OpenID Connect and OAuth2, are allowe
 |KO|OK
 
 |SSIN | ssin
-|street_RRN_Code | streetRrnCode
+|street_RRN | streetRrn
 |customerInformation | customer
 |descriptionStringLength140 | description
 a|

--- a/guide/src/main/asciidoc/json.adoc
+++ b/guide/src/main/asciidoc/json.adoc
@@ -59,7 +59,7 @@ This is because `enterpriseNumber` is a fixed denomination (declared in  Crossro
 {
   "name": "Belgacom",
   "employerId": 93017373,
-  "organization": {
+  "enterprise": {
     "enterpriseNumber": "0202239951"
     "href": "/organizations/0202239951"
   }

--- a/guide/src/main/asciidoc/json.adoc
+++ b/guide/src/main/asciidoc/json.adoc
@@ -21,7 +21,7 @@ Following guidelines SHOULD be respected when determining a name for a JSON prop
 * use American English
 * do not use underscores (_), hyphens (-) or dots (.) in a property name, nor use a digit as first letter
 * don't use overly generic terms like `info(rmation)` and `data` as property name or as part of it
-* the name should refer to the business meaning of its value rather than how it is defined
+* the name should refer to the business meaning of its value in relation to the object in which it is specified, rather than how it is defined
 * omit parts of the name that are already clear from the context
 
 Properties used from other standards, like OpenID Connect and OAuth2, are allowed to deviate from this rule.
@@ -31,9 +31,9 @@ Properties used from other standards, like OpenID Connect and OAuth2, are allowe
 |KO|OK
 
 |SSIN | ssin
-|partnerSSIN | partnerSsin
+|street_RRN_Code | streetRrnCode
 |customerInformation | customer
-|descriptionString | description
+|descriptionStringLength140 | description
 a|
 ```JSON
 "country": {
@@ -59,8 +59,9 @@ This is because `enterpriseNumber` is a fixed denomination (declared in  Crossro
 {
   "name": "Belgacom",
   "employerId": 93017373,
-  "enterprise": {
+  "organization": {
     "enterpriseNumber": "0202239951"
+    "href": "/organizations/0202239951"
   }
 }
 ```

--- a/guide/src/main/asciidoc/json.adoc
+++ b/guide/src/main/asciidoc/json.adoc
@@ -14,14 +14,15 @@ Service consumers should be aware that JSON objects can always be extended with 
 [rule, jsn-naming]
 .Naming of JSON properties
 ====
-All JSON property names are in American English and are written in _lowerCamelCase_ notation.
-This also applies to abbreviations part of a property name : all letters after the first one should always be lowercase.
+Following guidelines SHOULD be respected when determining a name for a JSON property:
 
-Do not use underscores (_), hyphens (-) or dots (.) in a property name, nor use a digit as first letter.
-
-Overly generic terms like `info(rmation)` and `data` SHOULD NOT be used as property name or as part of it.
-
-A JSON property SHOULD refer to the business meaning of its value rather than how it is defined.
+* use  _lowerCamelCase_ notation
+** also for abbreviations: all letters after the first should be lowercase
+* use American English
+* do not use underscores (_), hyphens (-) or dots (.) in a property name, nor use a digit as first letter
+* don't use overly generic terms like `info(rmation)` and `data` as property name or as part of it
+* the name should refer to the business meaning of its value rather than how it is defined
+* omit parts of the name that are already clear from the context
 
 Properties used from other standards, like OpenID Connect and OAuth2, are allowed to deviate from this rule.
 ====
@@ -33,13 +34,31 @@ Properties used from other standards, like OpenID Connect and OAuth2, are allowe
 |partnerSSIN | partnerSsin
 |customerInformation | customer
 |descriptionString | description
+a|
+```JSON
+"country": {
+  "countryNisCode": 150,
+  "countryIsoCode": "BE",
+  "countryName": "Belgium"
+}
+```
+a|
+```JSON
+"country": {
+  "nisCode": 150,
+  "isoCode": "BE",
+  "name": "Belgium"
+}
+```
 |===
 
+In below example, `enterpriseNumber` should be used even though the `enterprise` prefix is clear by its context.
+This is because `enterpriseNumber` is a fixed denomination (declared in  Crossroads Bank for Enterprises) and using just `number` would rather cause confusion to type of identifier being used.
 [subs="normal"]
 ```json
 {
   "name": "Belgacom",
-  "nssoNbr": 93017373,
+  "employerId": 93017373,
   "enterprise": {
     "enterpriseNumber": "0202239951"
   }
@@ -62,7 +81,7 @@ a|[subs="normal"]
 ```json
 {
   "name": "Belgacom",
-  "nssoNbr": 93017373,
+  "employerId": 93017373,
   "enterprise": null
 }
 ```
@@ -71,7 +90,7 @@ a|[subs="normal"]
 ```json
 {
   "name": "Belgacom",
-  "nssoNbr": 93017373
+  "employerId": 93017373
 }
 ```
 |===
@@ -84,7 +103,7 @@ a|[subs="normal"]
 ```json
 {
   "name": "Belgacom",
-  "nssoNbr": 93017373
+  "employerId": 93017373
 }
 ```
 
@@ -92,7 +111,7 @@ a|[subs="normal"]
 a|[subs="normal"]
 ```json
 {
-  "nssoNbr": 93017373,
+  "employerId": 93017373,
   "name": "Belgacom"
 }
 ```

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -259,20 +259,13 @@ GET /enterprises/{enterpriseNumber}
 ====
 A code SHOULD be named by the concept it represents.
 If multiple coding schemes may be used within a context, a suffix can be added to the name to disambiguate.
-If a code is represented together with its description, an object can be used with properties `code` and `description`.
+If a concept is represented both by its code and its description(s), an object can be used.
 ====
 
 ====
 // TODO refer to belgif types
 
-GET /municipalities/{municipality} //or code?
 
-```JSON
-{
-  "code": 10000,
-  "description": "Brussels"
-}
-```
 
 Context in which only Country NIS coding scheme is being used, the data type is clear from the OpenAPI definition
 ```YAML
@@ -293,18 +286,39 @@ Address:
       $ref: CountryNis
 ```
 
+GET /refData/economicalActivities/{economicalActivity}
+
+```JSON
+{
+  "code": "A",
+  "description": {
+    "nl": "Landbouw, bosbouw en visserij",
+    "fr": "Agriculture, sylviculture et pêche"
+  }
+}
+```
+
+GET /municipalities/{municipality}
+
+```JSON
+{
+  "code": 10000,
+  "name": "Brussels"
+}
+```
+
 GET /addresses/{addressId}
 
 ```YAML
 {
   "municipality": {
     "code": 10000,
-    "description": "Brussels"
+    "name": "Brussels"
   },
   "country": {
     "nisCode": 150,
     "isoCode": "BE",
-    "description": {
+    "name": {
       "nl": "België",
       "fr": "Belgique"
     }
@@ -330,14 +344,14 @@ MunicipalityWithDescription:
     description:
       type: string
 
-CountryWithDescription:
+CountryWithName:
   type: object
   properties:
     nisCode:
       $ref: #/components/schemas/CountryNis
     isoCode:
       $ref: #/components/schemas/CountryIso
-    description:
+    name:
       type: #/components/schemas/LocalizedString
 ```
 

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -207,7 +207,7 @@ Ssin:
 Country NIS code is a three-digit code, the first digit cannot be a zero.
 
 ```YAML
-CountryNis:
+CountryNisCode:
   description: NIS code representing a country as defined by statbel.fgov.be
   type: integer
   minimum: 100
@@ -220,47 +220,51 @@ CountryNis:
 [rule, id-name]
 .Identifier name
 ====
-Following naming guidelines should be applied when using an identifier or code within a REST API:
+Following naming guidelines should be applied when using an identifier or code in a REST API:
 
-* as JSON property
-** within an object that represents the entire or part of a resource: `id` or `code`
-** used to reference a resource within another one's representation: property name should designate the relation between the resources (see <<json-property-naming, JSON property naming>>); no need to suffix with `id` or `code`
-* path parameter: `id`, `code`. MAY be prefixed with the resource type to disambiguate if there are multiple identifiers as path parameters
-* query search parameter: use same name as the document property (see <<filtering>>)
+* JSON property:
+** within an object that represents the entire or part of a resource: use `id` or `code`
+** to reference a resource within another one's representation: property name should designate the relation between the resources (see <<json-property-naming, JSON property naming>>); no need to suffix with `id` or `code`
+* path parameter: use `id` or `code`, OPTIONALLY prefixed with the resource type to disambiguate when there are multiple identifiers as path parameters
+* query search parameter: use same name as the property in the JSON resource representation of the response (see <<filtering>>)
 
-As an exception, when a standardized name for the business identifier already exists, its use is always preferred over `id` or `code`.
+As an exception, use the standardized name for the business identifier if one exists, rather than `id` or `code`.
 
-If multiple identifiers or coding schemes may be used within a context, a suffix can be added to the name to disambiguate.
+If multiple identifiers or coding schemes may be used within the same context, a suffix can be added to the name to disambiguate.
 ====
-
-//rationale:
-// keep it as short as possible, without causing confusion
-// the OpenAPI specification provides sufficient documentation which exact values are expected
-// JSON property names can be better aligned with semantic web standards (relation to containing resource, no suffix with identifier type)
-// in path params, code resources usually doesn't have sub-resources (they're part of refData). Consistently repeating the resource type from the collection is verbose.
 
 .Identifier name
 ====
 
 ```
 GET /stores/{storeId}/orders/{orderId} <1>
-
+```
+```YAML
 {
-  "id": 123,  <2>
-  "customer": 456, <3>
+  "id": 123,  #<2>
+  "customer": 456, #<3>
   "store": {
-     "id": 789, <4>
+     "id": 789, #<4>
      "href": "/stores/789"
   },
   "paymentMethod": "creditCard",
   "deliveryMethod": {
-     "code": "deliveredAtHome", <2>
+     "code": "deliveredAtHome", #<5>
      "href": "/refData/deliveryMethods/deliveredAtHome"
   }
 }
+```
 
-GET /refData/deliveryMethods/{code}
+<1> path parameter: `id` prefixed with resource type to be able to distinguish both parameters
+<2> `id` as property of the consulted resource
+<3> identifier used to reference another resource. JSON property name designates relation to the other resource.
+<4> `id` as property in a partial representation of a `store` resource
+<5> `code` as property in a partial representation of a `deliveryMethod` resource
 
+```
+GET /refData/deliveryMethods/{code} <1>
+```
+```YAML
 {
   "code": "deliveredAtHome",
   "description": {
@@ -269,39 +273,31 @@ GET /refData/deliveryMethods/{code}
      "fr": "Livré à domicile"
   }
 }
-
-DeliveryMethod:
-  type: string
-  enum:
-  - deliveryAtHome
-  - pickUpAtStore
 ```
-<1> path parameter: `id` prefixed with resource type to be able to distinguish both parameters
-<2> `id` as property name within the resource
-<3> identifier used to reference another resource. JSON property name designates relation with the other resource.
-<4> `id` as property name of a partial representation of a `store` resource
+<1> Since there are no child resources with other path parameters, simply `code` suffices
+====
 
-
-GET /persons/{ssin}
+.Standardized business identifiers
+====
+```
+GET /persons/{ssin} <1>
+```
 ```YAML
 {
-  "ssin": "12345678901",
-  "partner": "2345678902", # value is of type Ssin
-  "civilState": 1
+  "ssin": "12345678901", <1>
+  "partner": "2345678902", <2>
+  "civilStatus": 1
 }
 ```
+<1> Standardized business identifier name `Ssin` is preferred over `id`.
+<2> JSON property name designates relation to the other resource. The OpenAPI specification declares the expected value to be of type `Ssin`.
+====
 
-GET /municipalities/{code}
-
-```JSON
-{
-  "code": 10000,
-  "name": "Brussels"
-}
+.Multiple types of identifiers
+====
 ```
-
 GET /addresses/{addressId}
-
+```
 ```YAML
 {
   "municipality": {
@@ -309,8 +305,8 @@ GET /addresses/{addressId}
     "name": "Brussels"
   },
   "country": {
-    "nisCode": 150,
-    "isoCode": "BE",
+    "nisCode": 150, <1>
+    "isoCode": "BE", <1>
     "name": {
       "nl": "België",
       "fr": "Belgique"
@@ -318,137 +314,7 @@ GET /addresses/{addressId}
   }
 }
 ```
-
-
-`enterpriseNumber` is a standard business name for the CBE enterprise identifier, so it should be used instead of `id`:
-```
-GET /enterprises/{enterpriseNumber}
-{
-   "enterpriseNumber": "0202239951"
-}
-```
-====
-
-====
-// TODO refer to belgif types, consolidate the examples
-
-
-
-Context in which only Country NIS coding scheme is being used, the data type is clear from the OpenAPI definition
-```YAML
-
-"address": {
-  # ...
-  "municipality": 12345,
-  "country": 150,
-}
-
-Address:
-  type: object
-  properties:
-    # ...
-    municipality:
-      $ref: Municipality
-    country:
-      $ref: CountryNis
-```
-
-GET /refData/economicalActivities/{code}
-
-```JSON
-{
-  "code": "A",
-  "description": {
-    "nl": "Landbouw, bosbouw en visserij",
-    "fr": "Agriculture, sylviculture et pêche"
-  }
-}
-```
-
-
-
-```YAML
-Address:
-  type: object
-  properties:
-    # ...
-    municipality:
-      $ref: #/components/schemas/MunicipalityWithDescription
-    country:
-      $ref: #/components/schemas/CountryWithDescription
-
-MunicipalityWithDescription:
-  type: object
-  properties:
-    code:
-      $ref: #/components/schemas/Municipality
-    description:
-      type: string
-
-CountryWithName:
-  type: object
-  properties:
-    nisCode:
-      $ref: #/components/schemas/CountryNis
-    isoCode:
-      $ref: #/components/schemas/CountryIso
-    name:
-      type: #/components/schemas/LocalizedString
-```
-
-*Impacted types*
-
-```YAML
-Municipality:
-  description: Numeric code to identify a Belgian municipality
-  #municipality codes are the same in BeSt address and NIS code list
-  type: integer
-  minimum: 10000
-  maximum: 99999
-BelgianRegion:
-  description: Belgian Region represented by an ISO 3166-2:BE code
-  type: string
-  enum:
-    - BE-BRU
-    - BE-WAL
-    - BE-VLG
-CountryNis:
-  description: NIS code representing a country as defined by statbel.fgov.be
-  type: integer
-  minimum: 100
-  maximum: 999
-CountryIso: # or CountryIsoAlpha2?
-  description: Country represented by an ISO 3166-1 alpha-2 code
-  type: string
-  pattern: "^[A-Z]{2}$"
-CountryWithHistoricIso:
-  description: Country represented by an ISO 3166-1 alpha-2 (current country) or ISO 3166-3 alpha-4 (former country) code
-  type: string
-  pattern: "^[A-Z]{2}([A-Z]{2})?$"
-StreetRrn:
-  description: Street code assigned by National Registry #not part of BeST address
-  type: integer
-  minimum: 1
-  maximum: 9999
-
-Gender: #back to original v1
-  description: 'Gender of a person, following the ISO 5218 standard: 0 = Unknown, 1 = male, 2 = female'
-  type: integer
-  enum:
-    - 0
-    - 1
-    - 2
-HouseholdRelationType: #beta
-  description: The type of relation of a household member to the household reference person, represented by a code assigned by the National Register
-  type: integer
-  minimum: 1
-  maximum: 99
-CivilState: #beta
-  description: The civil state of a person, represented by a code assigned by the National Register
-  type: integer
-  minimum: 1
-  maximum: 99
-```
+<1> Prefixes `nis` and `iso` disambiguate between two types of country identifiers used in a single context
 ====
 
 [[document-consult,Consult (Document)]]

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -34,7 +34,7 @@ In that case *prefer associations and create <<links,links>>* to other APIs from
 [rule, id-choice]
 .Choice of identifier
 ====
-The _identity key_ of a document resource is preferably a _natural business identifier_ uniquely identifying the business resource like an ISBN number or SSIN. If such key does not exist, a _surrogate or technical key_ can be created.  
+The _identity key_ of a document resource is preferably a _natural business identifier_ uniquely identifying the business resource like an ISBN or SSIN. If such key does not exist, a _surrogate or technical key_ can be created.
 ====
 
 New types of identifiers should be designed carefully. Once an identifier has been introduced, it may get widespread usage in various systems even beyond the scope for which it was initially designed, making it very hard to change its structure later on.
@@ -235,8 +235,8 @@ If multiple identifiers or coding schemes may be used within a context, a suffix
 //rationale:
 // keep it as short as possible, without causing confusion
 // the OpenAPI specification provides sufficient documentation which exact values are expected
-// JSON property names can be aligned with semantic web standards
-// in path params, code resources usually doesn't have subresources
+// JSON property names can be better aligned with semantic web standards (relation to containing resource, no suffix with identifier type)
+// in path params, code resources usually doesn't have sub-resources (they're part of refData). Consistently repeating the resource type from the collection is verbose.
 
 .Identifier name
 ====
@@ -282,7 +282,7 @@ DeliveryMethod:
 
 
 GET /persons/{ssin}
-```JSON
+```YAML
 {
   "ssin": "12345678901",
   "partner": "2345678902", # value is of type Ssin
@@ -689,7 +689,7 @@ a|
 
 Use `PATCH` when you like to do a partial update of a document resource.
 
-The `PATCH` message MUST be conform to the JSON Merge Patch (https://tools.ietf.org/html/rfc7386[RFC 7386]) specification:
+The `PATCH` message MUST conform to the JSON Merge Patch (https://tools.ietf.org/html/rfc7386[RFC 7386]) specification:
 
 * JSON properties in the request overwrite the ones in the previous resource state
 * properties with value `null` in the request are removed from the resource
@@ -835,14 +835,14 @@ For example, a REST API may return this response code when a client tries to DEL
 ====
 
 [[long-running-tasks]]
-=== Long running tasks
+=== Long-running tasks
 
 Some operations need to be performed asynchronously, as they take too long to complete.
 
 [rule, lng-task]
-.Long running tasks
+.Long-running tasks
 ====
-Long running tasks MUST be represented as a resource.
+Long-running tasks MUST be represented as a resource.
 The task resource is created using a POST action returning a `202 Accepted` response containing the URL of the task in the `Location` HTTP header.
 It can then be fetched by the client to get the processing status of the task.
 
@@ -856,7 +856,7 @@ When GETting the task resource, the response can be:
 Variations on the above may be required, e.g. if the task has no output, the response on success may be `200 OK` without a `Location` header.
 The schema https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml] defines the representation of a task's status.
 
-.Long running task
+.Long-running task
 ====
 *Submitting the task*
 
@@ -913,7 +913,7 @@ Content-Type: application/json;charset=UTF-8
   "self": "/images/tasks/1",
   "status": {
     "state": "done",
-    "completed":"2018-09-13T02:10:00Z",
+    "completed":"2018-09-13T02:10:00Z"
   }
 }
 ```

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -220,12 +220,13 @@ CountryNis:
 [rule, id-name]
 .Identifier name
 ====
-Following naming guidelines should be applied when designating an identifier of code within a REST API:
+Following naming guidelines should be applied when using an identifier or code within a REST API:
 
-* as JSON property in an object that represents the entire or part of a resource: use: `id` or `code`
-* as JSON property value to reference the resource within another one's representation: property name designates the relation between the resources (see <<json-property-naming, JSON property naming>>); no need to suffix with `id` or `code`.
-* path parameter: `id`, `code`. May be prefixed with <resourceType> to disambiguate if there are multiple identifiers as path parameters.
-* query search parameter: same name as the document property (see <<filtering>>)
+* as JSON property
+** within an object that represents the entire or part of a resource: `id` or `code`
+** used to reference a resource within another one's representation: property name should designate the relation between the resources (see <<json-property-naming, JSON property naming>>); no need to suffix with `id` or `code`
+* path parameter: `id`, `code`. MAY be prefixed with the resource type to disambiguate if there are multiple identifiers as path parameters
+* query search parameter: use same name as the document property (see <<filtering>>)
 
 As an exception, when a standardized name for the business identifier already exists, its use is always preferred over `id` or `code`.
 
@@ -352,7 +353,7 @@ Address:
       $ref: CountryNis
 ```
 
-GET /refData/economicalActivities/{economicalActivity}
+GET /refData/economicalActivities/{code}
 
 ```JSON
 {

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -149,25 +149,25 @@ Depending on context, the OpenAPI data type may enumerate the list of allowed va
 
 .Code
 ====
-// TODO: replace PensionType fabricated example with a real one
-`GET /refData/pensionTypes/{code}` with `code` of type `PensionTypeCode`
+`GET /refData/paymentMethods/{code}` with `code` of type `PaymentMethodCode`
 
 As string with enumeration:
 ```YAML
-PensionTypeCode:
+PaymentMethodCode:
   type: string
   enum:
-  - retirementPension
-  - survivalPension
-  - guaranteedIncomeElderly
+  - cash
+  - wireTransfer
+  - creditCard
+  - debitCard
 ```
 
 As string with regular expression: 
 ```YAML
-PensionTypeCode:
+PaymentMethodCode:
   type: string
   pattern: "^[A-Za-z0-9]+$"
-  example: "retirementPension"
+  example: "debitCard"
 ```
 ====
 
@@ -189,6 +189,7 @@ An employer ID may be of variable length. Leading zeroes are ignored and most of
 EmployerId:
   description: Definitive or provisional NSSO number, assigned to each registered employer or local or provincial administration.
   type: integer
+  format: int64
   minimum: 0
   maximum: 5999999999
   example: 21197
@@ -203,10 +204,10 @@ Ssin:
   pattern: '^\d{11}$'
 ```
 
-Country NIS code is a three digit code, the first digit cannot be a zero.
+Country NIS code is a three-digit code, the first digit cannot be a zero.
 
 ```YAML
-CountryNisCode:
+CountryNis:
   description: NIS code representing a country as defined by statbel.fgov.be
   type: integer
   minimum: 100
@@ -219,12 +220,23 @@ CountryNisCode:
 [rule, id-name]
 .Identifier name
 ====
-An identifier that's not a code should be named `id` unless there already exists another standardized name for the business identifier.
+Following naming guidelines should be applied when designating an identifier of code within a REST API:
 
-In a JSON representation, it SHOULD NOT be prefixed unless the identifier is not of the resource on which the operation applies and there's ambiguity.
+* as JSON property in an object that represents the entire or part of a resource: use: `id` or `code`
+* as JSON property value to reference the resource within another one's representation: property name designates the relation between the resources (see <<json-property-naming, JSON property naming>>); no need to suffix with `id` or `code`.
+* path parameter: `id`, `code`. May be prefixed with <resourceType> to disambiguate if there are multiple identifiers as path parameters.
+* query search parameter: same name as the document property (see <<filtering>>)
 
-If the identifier is used as path parameter, it should be prefixed by the resource type.
+As an exception, when a standardized name for the business identifier already exists, its use is always preferred over `id` or `code`.
+
+If multiple identifiers or coding schemes may be used within a context, a suffix can be added to the name to disambiguate.
 ====
+
+//rationale:
+// keep it as short as possible, without causing confusion
+// the OpenAPI specification provides sufficient documentation which exact values are expected
+// JSON property names can be aligned with semantic web standards
+// in path params, code resources usually doesn't have subresources
 
 .Identifier name
 ====
@@ -234,36 +246,90 @@ GET /stores/{storeId}/orders/{orderId} <1>
 
 {
   "id": 123,  <2>
-  "clientId": 456, <3>
+  "customer": 456, <3>
   "store": {
      "id": 789, <4>
      "href": "/stores/789"
+  },
+  "paymentMethod": "creditCard",
+  "deliveryMethod": {
+     "code": "deliveredAtHome", <2>
+     "href": "/refData/deliveryMethods/deliveredAtHome"
+  }
+}
+
+GET /refData/deliveryMethods/{code}
+
+{
+  "code": "deliveredAtHome",
+  "description": {
+     "nl": "Geleverd aan huis",
+     "en": "Delivered at home",
+     "fr": "Livré à domicile"
+  }
+}
+
+DeliveryMethod:
+  type: string
+  enum:
+  - deliveryAtHome
+  - pickUpAtStore
+```
+<1> path parameter: `id` prefixed with resource type to be able to distinguish both parameters
+<2> `id` as property name within the resource
+<3> identifier used to reference another resource. JSON property name designates relation with the other resource.
+<4> `id` as property name of a partial representation of a `store` resource
+
+
+GET /persons/{ssin}
+```JSON
+{
+  "ssin": "12345678901",
+  "partner": "2345678902", # value is of type Ssin
+  "civilState": 1
+}
+```
+
+GET /municipalities/{code}
+
+```JSON
+{
+  "code": 10000,
+  "name": "Brussels"
+}
+```
+
+GET /addresses/{addressId}
+
+```YAML
+{
+  "municipality": {
+    "code": 10000,
+    "name": "Brussels"
+  },
+  "country": {
+    "nisCode": 150,
+    "isoCode": "BE",
+    "name": {
+      "nl": "België",
+      "fr": "Belgique"
+    }
   }
 }
 ```
-<1> path parameter: prefixed with resource type
-<2> use id as JSON property name for the resource being consulted
-<3> identifier doesn't refer to the consulted resource. It would be ambiguous with the order's id.
-<4> Clearly refers to the store's id, so no prefix required.
+
 
 `enterpriseNumber` is a standard business name for the CBE enterprise identifier, so it should be used instead of `id`:
 ```
 GET /enterprises/{enterpriseNumber}
 {
-   "enterpriseNumber":  "0202239951"
+   "enterpriseNumber": "0202239951"
 }
 ```
 ====
 
-.Code name
 ====
-A code SHOULD be named by the concept it represents.
-If multiple coding schemes may be used within a context, a suffix can be added to the name to disambiguate.
-If a concept is represented both by its code and its description(s), an object can be used.
-====
-
-====
-// TODO refer to belgif types
+// TODO refer to belgif types, consolidate the examples
 
 
 
@@ -298,33 +364,7 @@ GET /refData/economicalActivities/{economicalActivity}
 }
 ```
 
-GET /municipalities/{municipality}
 
-```JSON
-{
-  "code": 10000,
-  "name": "Brussels"
-}
-```
-
-GET /addresses/{addressId}
-
-```YAML
-{
-  "municipality": {
-    "code": 10000,
-    "name": "Brussels"
-  },
-  "country": {
-    "nisCode": 150,
-    "isoCode": "BE",
-    "name": {
-      "nl": "België",
-      "fr": "Belgique"
-    }
-  }
-}
-```
 
 ```YAML
 Address:
@@ -376,7 +416,7 @@ CountryNis:
   type: integer
   minimum: 100
   maximum: 999
-CountryIso:
+CountryIso: # or CountryIsoAlpha2?
   description: Country represented by an ISO 3166-1 alpha-2 code
   type: string
   pattern: "^[A-Z]{2}$"

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -64,7 +64,7 @@ When designing an identifier, various requirements may be of importance specific
 [[new-identifiers]]
 For new identifiers, a string based format SHOULD be used: textual lowerCamelCase string codes, http://tools.ietf.org/html/rfc4122[UUID^], URI or other custom formats. Take into account the requirements that follow from the ways the identifier will be used.
 
-Each identifier MUST be represented by only one single string value, so that a string equality check can be used to test if two identifiers are identitical. This means that capitalization, whitespace or leading zeroes are significant.
+Each identifier MUST be represented by only one single string value, so that a string equality check can be used to test if two identifiers are identical. This means that capitalization, whitespace or leading zeroes are significant.
 
 In the OpenAPI data type for the identifier, a regular expression may be specified if helpful for input validation or as hint of the structure (e.g. to avoid whitespace or wrong capitalization), but shouldn't be too restrictive in order to be able to evolve the format. 
 
@@ -176,7 +176,7 @@ PensionTypeCode:
 ====
 When defining the type for a property representing an existing numerical code or identifier:
 
-* Identifiers that are commonly represented (e.g. when displayed or inputted by a user) with *leading zeros* present SHOULD be represented using a string type. A regular expression SHOULD be specified in the OpenAPI data type to avoid erronous values (i.e. without leading zeros).
+* Identifiers that are commonly represented (e.g. when displayed or inputted by a user) with *leading zeros* present SHOULD be represented using a string type. A regular expression SHOULD be specified in the OpenAPI data type to avoid erroneous values (i.e. without leading zeros).
 * Otherwise, use an integer based type. It is RECOMMENDED to further restrict the format of the type (e.g. `format: int32` and using `minimum`/`maximum`).
 
 For new identifiers, it is not recommended to use a number type however as stated in <<new-identifiers>>
@@ -219,7 +219,7 @@ CountryNisCode:
 [rule, id-name]
 .Identifier name
 ====
-The identifier should be named `id` unless there already exists another standardized name for the business identifier.
+An identifier that's not a code should be named `id` unless there already exists another standardized name for the business identifier.
 
 In a JSON representation, it SHOULD NOT be prefixed unless the identifier is not of the resource on which the operation applies and there's ambiguity.
 
@@ -252,6 +252,147 @@ GET /enterprises/{enterpriseNumber}
 {
    "enterpriseNumber":  "0202239951"
 }
+```
+====
+
+.Code name
+====
+A code SHOULD be named by the concept it represents.
+If multiple coding schemes may be used within a context, a suffix can be added to the name to disambiguate.
+If a code is represented together with its description, an object can be used with properties `code` and `description`.
+====
+
+====
+// TODO refer to belgif types
+
+GET /municipalities/{municipality} //or code?
+
+```JSON
+{
+  "code": 10000,
+  "description": "Brussels"
+}
+```
+
+Context in which only Country NIS coding scheme is being used, the data type is clear from the OpenAPI definition
+```YAML
+
+"address": {
+  # ...
+  "municipality": 12345,
+  "country": 150,
+}
+
+Address:
+  type: object
+  properties:
+    # ...
+    municipality:
+      $ref: Municipality
+    country:
+      $ref: CountryNis
+```
+
+GET /addresses/{addressId}
+
+```YAML
+{
+  "municipality": {
+    "code": 10000,
+    "description": "Brussels"
+  },
+  "country": {
+    "nisCode": 150,
+    "isoCode": "BE",
+    "description": {
+      "nl": "België",
+      "fr": "Belgique"
+    }
+  }
+}
+```
+
+```YAML
+Address:
+  type: object
+  properties:
+    # ...
+    municipality:
+      $ref: #/components/schemas/MunicipalityWithDescription
+    country:
+      $ref: #/components/schemas/CountryWithDescription
+
+MunicipalityWithDescription:
+  type: object
+  properties:
+    code:
+      $ref: #/components/schemas/Municipality
+    description:
+      type: string
+
+CountryWithDescription:
+  type: object
+  properties:
+    nisCode:
+      $ref: #/components/schemas/CountryNis
+    isoCode:
+      $ref: #/components/schemas/CountryIso
+    description:
+      type: #/components/schemas/LocalizedString
+```
+
+*Impacted types*
+
+```YAML
+Municipality:
+  description: Numeric code to identify a Belgian municipality
+  #municipality codes are the same in BeSt address and NIS code list
+  type: integer
+  minimum: 10000
+  maximum: 99999
+BelgianRegion:
+  description: Belgian Region represented by an ISO 3166-2:BE code
+  type: string
+  enum:
+    - BE-BRU
+    - BE-WAL
+    - BE-VLG
+CountryNis:
+  description: NIS code representing a country as defined by statbel.fgov.be
+  type: integer
+  minimum: 100
+  maximum: 999
+CountryIso:
+  description: Country represented by an ISO 3166-1 alpha-2 code
+  type: string
+  pattern: "^[A-Z]{2}$"
+CountryWithHistoricIso:
+  description: Country represented by an ISO 3166-1 alpha-2 (current country) or ISO 3166-3 alpha-4 (former country) code
+  type: string
+  pattern: "^[A-Z]{2}([A-Z]{2})?$"
+StreetRrn:
+  description: Street code assigned by National Registry #not part of BeST address
+  type: integer
+  minimum: 1
+  maximum: 9999
+
+Gender: #back to original v1
+  description: 'Gender of a person, following the ISO 5218 standard: 0 = Unknown, 1 = male, 2 = female'
+  type: integer
+  enum:
+    - 0
+    - 1
+    - 2
+HouseholdRelationType: #beta
+  description: The type of relation of a household member to the household reference person, represented by a code assigned by the National Register
+  type: integer
+  minimum: 1
+  maximum: 99
+CivilState: #beta
+  description: The civil state of a person, represented by a code assigned by the National Register
+  type: integer
+  minimum: 1
+  maximum: 99
 ```
 ====
 
@@ -294,7 +435,7 @@ a|
 ----
 
 3+|Most used response codes 
-​​|<<http-200,200>>
+|<<http-200,200>>
 |OK
 |Default success code if the document exists.
 


### PR DESCRIPTION
* omit redundant names in JSON properties clear from context
* naming guidelines for codes

#94 