### PR TITLE
Clarify the meaning of 'total' w.r.t. filtering

### DIFF
--- a/guide/src/main/asciidoc/reserved.adoc
+++ b/guide/src/main/asciidoc/reserved.adoc
@@ -59,7 +59,7 @@ Default sorting direction is ascending. To indicate descending direction, the pr
 | Ref
 
 |[[rel-next]]next
-|The next-reference contains the absolute URL of the next page in a paged collection.
+|The next-reference contains the absolute URL of the next page in a paged collection result.
 a|
 [source,json, subs=normal]
 ----
@@ -68,7 +68,7 @@ a|
 | <<Links>>
 
 |[[rel-previous]]prev
-|The previous-reference contains the absolute URL of the previous page in a paged collection.
+|The previous-reference contains the absolute URL of the previous page in a paged collection result.
 a|
 [source,json, subs=normal]
 ----
@@ -95,7 +95,7 @@ a|
 | <<Links>>
 
 |[[rel-first]]first
-|A reference (absolute URL) to the first page in a paged collection.
+|A reference (absolute URL) to the first page in a paged collection result.
 a|
 [source,json, subs=normal]
 ----
@@ -104,7 +104,7 @@ a|
 | <<Pagination>>
 
 |[[rel-last]]last
-|A reference (absolute URL) to the last page in a paged collection.
+|A reference (absolute URL) to the last page in a paged collection result.
 a|
 [source,json, subs=normal]
 ----
@@ -113,22 +113,22 @@ a|
 | <<Pagination>>
 
 | items
-| an array with the items of a collection resource
+| an array with the items of a collection result.
 |
 | <<Collection>>
 
 | total
-| the total number of items in a collection resource
+| the total number of items in a collection result, after filtering.
 |
 | <<Collection>>
 
 | page
-| the index of a page in a paged collection
+| the index of a page in a paged collection result
 |
 | <<Pagination>>
 
 | pageSize
-| the maximum number of items in a page of a paged collection
+| the maximum number of items in a page of a paged collection result.
 |
 | <<Pagination>>
 

--- a/guide/src/main/asciidoc/resources-collection.adoc
+++ b/guide/src/main/asciidoc/resources-collection.adoc
@@ -27,7 +27,7 @@ The representation of a collection MUST contain a list of links to child resourc
 * Each item object MAY be extended with some key business properties, needed for display in a master view.
 * In case the collection is empty, the `items` property MUST have an empty array as value.
 * The `title` attribute MAY be used to provide a human-readable description for an item, usable as display text for the link.
-* `total` is the reserved word for the number of items in the collection result set. It SHOULD be present when pagination is used or MAY be present otherwise.
+* `total` is the reserved word for the number of items in the collection result set. It is optional, but if used in combination with pagination, this parameter must correspond to the number of items regardless pagination, not the page size.
 ====
 
 CAUTION: A collection resource SHOULD always return a JSON object as top-level data structure to support extensibility. Do not return a JSON array, because the moment you like to add paging, hypermedia links, etc, your API will break.

--- a/guide/src/main/asciidoc/resources-collection.adoc
+++ b/guide/src/main/asciidoc/resources-collection.adoc
@@ -26,8 +26,8 @@ The representation of a collection MUST contain a list of links to child resourc
 * The unique business identifier SHOULD be present for each item.
 * Each item object MAY be extended with some key business properties, needed for display in a master view.
 * In case the collection is empty, the `items` property MUST have an empty array as value.
-* The `title` attribute MAY be used to provide a human-readable description for an item, usable as display text for the link.
-* `total` is the reserved word for the number of items in the collection result set. It is optional, but if used in combination with pagination, this parameter must correspond to the number of items regardless pagination, not the page size.
+* The `title` property  MAY be used to provide a human-readable description for an item, usable as display text for the link.
+* The number of items in the collection result set MAY be included in the response using the `total` property. If the response is paginated, its value MUST correspond to the number of items regardless of pagination, rather than only the number of items in the current page.
 ====
 
 CAUTION: A collection resource SHOULD always return a JSON object as top-level data structure to support extensibility. Do not return a JSON array, because the moment you like to add paging, hypermedia links, etc, your API will break.

--- a/guide/src/main/asciidoc/resources-collection.adoc
+++ b/guide/src/main/asciidoc/resources-collection.adoc
@@ -27,7 +27,7 @@ The representation of a collection MUST contain a list of links to child resourc
 * Each item object MAY be extended with some key business properties, needed for display in a master view.
 * In case the collection is empty, the `items` property MUST have an empty array as value.
 * The `title` attribute MAY be used to provide a human-readable description for an item, usable as display text for the link.
-* `total` is the reserved word for all the items in the collection result.
+* `total` is the reserved word for the number of items in the collection result set. It SHOULD be present when pagination is used or MAY be present otherwise.
 ====
 
 CAUTION: A collection resource SHOULD always return a JSON object as top-level data structure to support extensibility. Do not return a JSON array, because the moment you like to add paging, hypermedia links, etc, your API will break.
@@ -280,10 +280,10 @@ Take into account the considerations http://zalando.github.io/restful-api-guidel
 | `page` |MANDATORY (offset-based); N/A (cursor-based) | index of the current page of items, should be 1-based (the default and first page is 1)
 | `first` | OPTIONAL | hyperlink to the first page
 | `last` | OPTIONAL | hyperlink to the last page
+| `total` | OPTIONAL | Total number of items across all pages. If query parameters are used to filter the result set, this is the total of the collection result set, not of the entire collection.
 
 |===
 
-Note that the `total` collection property, if used, MUST always present the total number of items across all pages.
 The names of the properties with hyperlink values and the `items` property are derived from the https://www.iana.org/assignments/link-relations/link-relations.xml[IANA registered link relations].
 
 .Reserved query parameters:


### PR DESCRIPTION
The `total` property is used to indicate the number of items in a collection, mostly used with pagination. It was not clear to me if this was the total in the entire collection or the total of the result set. These are different numbers if filtering is applied. Also it should be made explicit if the property can be used if no pagination is used.
