### PR TITLE
Add doc openapi resource to reserved paths

### DIFF
--- a/guide/src/main/asciidoc/api_specifications.adoc
+++ b/guide/src/main/asciidoc/api_specifications.adoc
@@ -96,8 +96,8 @@ Note that these are exceptions to the rule that API resource URLs shouldn't have
 ====
 ```
  /doc
-     /swagger.json
-     /swagger.yaml
+     /openapi.json
+     /openapi.yaml
      /<optional other documentation>
  /refData
      /<list1OfCodes>

--- a/guide/src/main/asciidoc/changelog.adoc
+++ b/guide/src/main/asciidoc/changelog.adoc
@@ -1,4 +1,6 @@
 == Changelog
+* 2023-xx-xx
+** add /doc/openapi.[json,yaml] to list of reserved resources <<Resource names>>
 * 2023-03-17
 ** Rule identifier with anchor added for each rule in the guide
 ** Updated <<rule-jsn-naming>>: naming of JSON properties

--- a/guide/src/main/asciidoc/reserved.adoc
+++ b/guide/src/main/asciidoc/reserved.adoc
@@ -187,7 +187,12 @@ However, for backwards compatibility reasons, headers with the `X-` prefix may s
 |===
 | path | Description        | Reference
 
-| /doc, /doc/swagger.yaml, /doc/swagger.json | API documentation (swagger file and other)  | <<doc-resource>>
+|
+/doc +
+/doc/swagger.yaml +
+/doc/swagger.json +
+/doc/openapi.yaml +
+/doc/openapi.json | API documentation (swagger file and other)  | <<doc-resource>>
 | /refData | resources representing reference data used in the API (i.e. code lists) | <<doc-resource>>
 | /health | API health status | <<health>>
 |===


### PR DESCRIPTION
Adds /doc/openapi.yaml and /doc/openapi.json to reserved resources and updates example with openapi instead of swagger