### PR TITLE
Replace links to Swagger schemas by OpenAPI

### DIFF
--- a/guide/src/main/asciidoc/errorhandling.adoc
+++ b/guide/src/main/asciidoc/errorhandling.adoc
@@ -10,7 +10,7 @@ For any problem occurred during processing, whether it be caused by the client o
 2.  a RFC 7807 problem detail message
 
 
-.Problem Details JSON schema (from link:https://github.com/belgif/openapi-problem/blob/master/src/main/swagger/problem/v1/problem-v1.yaml[problem-v1.yaml])
+.Problem Details JSON schema (from link:https://github.com/belgif/openapi-problem/blob/master/src/main/openapi/problem/v1/problem-v1.yaml[problem-v1.yaml])
 ```yaml
     Problem:
       description: A Problem Details object (RFC 7807)
@@ -190,7 +190,7 @@ Operation-specific problem types should still be documented.
 
 Specifying a default problem response ensures compatibility with clients that perform strict OpenAPI validation on response messages.
 
-.Default problem response (using `ProblemResponse` from https://github.com/belgif/openapi-problem/blob/master/src/main/swagger/problem/v1/problem-v1.yaml[problem-v1.yaml])
+.Default problem response (using `ProblemResponse` from https://github.com/belgif/openapi-problem/blob/master/src/main/openapi/problem/v1/problem-v1.yaml[problem-v1.yaml])
 ====
 ```YAML
 /orders/{orderId}/archive:
@@ -225,7 +225,7 @@ WARNING: `href` links to descriptions of standardized problem types will change 
 include::problems/badRequest.adoc[leveloffset=3]
 
 [[input-validation-schema]]
-.InputValidationProblem schema definition (from https://github.com/belgif/openapi-problem/blob/master/src/main/swagger/problem/v1/problem-v1.yaml[problem-v1.yaml])
+.InputValidationProblem schema definition (from https://github.com/belgif/openapi-problem/blob/master/src/main/openapi/problem/v1/problem-v1.yaml[problem-v1.yaml])
 ```yaml
 InputValidationProblem:
   type: object

--- a/guide/src/main/asciidoc/health.adoc
+++ b/guide/src/main/asciidoc/health.adoc
@@ -29,7 +29,7 @@ This internal information should be hidden from external clients for security re
 }
 ```
 
-The health resource is specified in https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml].
+The health resource is specified in https://github.com/belgif/openapi-common/blob/master/src/main/openapi/common/v1/common-v1.yaml[common-v1.yaml].
 Note that uppercase is used for the status values, which differs from the <<enum-rule>>, in order to align with existing health checks provided by frameworks like https://docs.spring.io/spring-boot/docs/2.3.1.RELEASE/reference/htmlsingle/#production-ready-health[Spring Boot] and https://download.eclipse.org/microprofile/microprofile-health-2.2/microprofile-health-spec.html[MicroProfile Health].
 The format of additional component-level details is not specified.
 

--- a/guide/src/main/asciidoc/hypermedia.adoc
+++ b/guide/src/main/asciidoc/hypermedia.adoc
@@ -21,7 +21,7 @@ CAUTION: For brevity, most URIs in the style guide examples are shortened, but i
 
 All `href` hyperlinks are derived from this minimal link type:
 
-.HttpLink JSON data type (from https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml])
+.HttpLink JSON data type (from https://github.com/belgif/openapi-common/blob/master/src/main/openapi/common/v1/common-v1.yaml[common-v1.yaml])
 ```YAML
 HttpLink:
   description: A base type of objects representing links to resources.
@@ -36,7 +36,7 @@ HttpLink:
 
 `self` hyperlinks are derived from the following type:
 
-.SelfLink JSON data type (from https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml])
+.SelfLink JSON data type (from https://github.com/belgif/openapi-common/blob/master/src/main/openapi/common/v1/common-v1.yaml[common-v1.yaml])
 ```YAML
 SelfLink:
   description: A base type representing a link to the resource's own location within its representation

--- a/guide/src/main/asciidoc/internationalization.adoc
+++ b/guide/src/main/asciidoc/internationalization.adoc
@@ -57,7 +57,7 @@ An API MAY offer to filter the representation to a single language by using the 
 
 A `LocalizedString` type is defined supporting the three official Belgian languages.
 
-.LocalizedString JSON Schema (from https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml])
+.LocalizedString JSON Schema (from https://github.com/belgif/openapi-common/blob/master/src/main/openapi/common/v1/common-v1.yaml[common-v1.yaml])
 ```YAML
 LocalizedString:
   description: A description specified in multiple languages

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -84,7 +84,7 @@ The table below lists some examples of identifiers, though it does not list all 
 |UUID 
 | "d9e35127-e9b1-4201-a211-2b52e52508df"
 a| 
-Type defined in https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml]
+Type defined in https://github.com/belgif/openapi-common/blob/master/src/main/openapi/common/v1/common-v1.yaml[common-v1.yaml]
 ```YAML
 Uuid:
   description: Universally Unique Identifier, as standardized in RFC 4122 and ISO/IEC 9834-8
@@ -604,7 +604,7 @@ The `PATCH` message MUST conform to the JSON Merge Patch (https://tools.ietf.org
 * properties not present in the request are preserved
 
 APIs should support both the MIME type of JSON merge patch `application/merge-patch+json` as the generic `application/json` JSON mime type.
-As JSON Merge Patch requests can not be fully specified as an OpenAPI data type, a MergePatch marker type should be used, defined in https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml].
+As JSON Merge Patch requests can not be fully specified as an OpenAPI data type, a MergePatch marker type should be used, defined in https://github.com/belgif/openapi-common/blob/master/src/main/openapi/common/v1/common-v1.yaml[common-v1.yaml].
 
 .JSON merge patch
 ====
@@ -762,7 +762,7 @@ When GETting the task resource, the response can be:
 ====
 
 Variations on the above may be required, e.g. if the task has no output, the response on success may be `200 OK` without a `Location` header.
-The schema https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml] defines the representation of a task's status.
+The schema https://github.com/belgif/openapi-common/blob/master/src/main/openapi/common/v1/common-v1.yaml[common-v1.yaml] defines the representation of a task's status.
 
 .Long-running task
 ====


### PR DESCRIPTION
Replace links to Swagger Belgif schemas by their OpenAPI equivalents