### PR TITLE
Status codes and method combinations

### DIFF
--- a/guide/src/main/asciidoc/methods.adoc
+++ b/guide/src/main/asciidoc/methods.adoc
@@ -3,11 +3,6 @@
 === GET
 **GET must be used to retrieve a representation of a resource.** It is a strict read-only method, which should never modify the state of the resource.
 
-
-=== HEAD
-**HEAD should be used to only retrieve the HTTP response headers​.** HEAD returns the same response as GET, except that the API returns an empty body. It is strictly read-only.
-
-
 === POST
 *POST must be used to <<create-resource,create a new resource>> in a collection or to execute a <<Controller,controller>> resource.*
 
@@ -43,6 +38,8 @@ If these can't be upgraded to add support, client and server may agree to work a
 === DELETE
 *DELETE must be used to remove a resource from its parent.* Once a DELETE request has been processed for a given resource, the resource can no longer be found by clients. Therefore, any future attempt to retrieve the resource’s state representation, using either GET or HEAD, must result in a 404 (“Not Found”)​ status returned by the API.
 
+=== HEAD
+**HEAD should be used to only retrieve the HTTP response headers​.** HEAD returns the same response as GET, except that the API returns an empty body. It is strictly read-only.
 
 === OPTIONS
 OPTIONS should be used to retrieve metadata that describes a resource’s available interactions.
@@ -50,61 +47,72 @@ OPTIONS should be used to retrieve metadata that describes a resource’s availa
  
 === How to use each method
 
+[rule, meth-http]
+.Use appropriate HTTP method
+====
+The HTTP methods code SHOULD be used that are appropriate for the type of action performed on the resource.
+
+Below table lists the usages of HTTPs methods for each resource archetype. Combinations explicitly excluded ( `-`) SHOULD NOT be used.
+
+====
+
+
 [cols="1,1,1,1,4,2", options="header"]
 |===
 |Method
-|Collection|Document
+|Document
+|Collection
 |Controller
 |Request body
 |Response body
 
-|GET
-|Yes
-|Yes	
-|Yes	
+|<<GET>>
+|<<document-consult, consult>>
+|<<collections-consult, consult>>
+|<<controller, idempotent actions without side effects>>
 |Empty
 |Resource(s) 
 
-|HEAD
-|Yes
-|Yes	
-|Yes	
-|Empty
-|Empty
-
-|POST
-|Yes
-|No	
-|Yes	
+|<<POST>>
+|-
+|<<create-resource, create document>>
+|<<controller, action with side effects or requiring request body>>
 |Representation of the created resource  
 or controller info
 |Optional
 
-|PUT
-|No
-|Yes	
-|No	
+|<<PUT>>
+|<<document-full-update, full update>>
+|-
+|-
 |Representation of the updated resource  
 |Optional
 
-|PATCH
-|No
-|Yes	
-|No	
+|<<PATCH>>
+|<<document-partial-update, partial update>>
+|-
+|-
 |Fields of the resource to update  
 |Optional
 
-|DELETE
-|Yes
-|Yes	
-|No	
+|<<DELETE>>
+|<<remove-document, remove>>
+|<<remove-collection-items,remove selection of items>>
+|-
 |Empty  
 |Optional
 
-|OPTIONS
-|Yes
-|Yes	
-|No	
+|<<HEAD>>
+|X
+|X
+|X
+|Empty
+|Empty
+
+|<<OPTIONS>>
+|X
+|X
+|X
 |Empty  
 |Optional
 

--- a/guide/src/main/asciidoc/methods.adoc
+++ b/guide/src/main/asciidoc/methods.adoc
@@ -50,9 +50,9 @@ OPTIONS should be used to retrieve metadata that describes a resource’s availa
 [rule, meth-http]
 .Use appropriate HTTP method
 ====
-The HTTP methods code SHOULD be used that are appropriate for the type of action performed on the resource.
+The HTTP methods SHOULD be used that are appropriate for the type of action performed on the resource.
 
-Below table lists the usages of HTTPs methods for each resource archetype. Combinations explicitly excluded ( `-`) SHOULD NOT be used.
+The table below lists the usages of HTTP methods for each resource archetype. Combinations explicitly excluded ( `-`) SHOULD NOT be used.
 
 ====
 

--- a/guide/src/main/asciidoc/resources-controller.adoc
+++ b/guide/src/main/asciidoc/resources-controller.adoc
@@ -1,3 +1,4 @@
+[[controller]]
 == Controller
 
 A controller resource models a procedural concept. Controller resources are like executable functions, with parameters and return values; inputs and outputs.

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -520,6 +520,7 @@ If this proves to be an issue, this might however indicate that the array elemen
 
 Use of the JSON Patch standard, an alternative to JSON Merge Patch, is not recommended, as it proves to be difficult to implement.
 
+[[document-full-update]]
 ==== Full update
 
 Use `PUT` when you like to do a complete update of a document resource.
@@ -593,6 +594,7 @@ a|
 |===
 ====
 
+[[document-partial-update]]
 ==== Partial update
 
 Use `PATCH` when you like to do a partial update of a document resource.

--- a/guide/src/main/asciidoc/statuscodes.adoc
+++ b/guide/src/main/asciidoc/statuscodes.adoc
@@ -10,7 +10,7 @@
 ====
 The HTTP response status code SHOULD be returned that best describes the outcome of the treatment of the request.
 
-Below table list most common combinations of a status code for each HTTP method, though may not be exhaustive. Combinations explicitly excluded ( `-`) SHOULD NOT be used.
+The table below list most common combinations of a status code for each HTTP method, though may not be exhaustive. Combinations explicitly excluded ( `-`) SHOULD NOT be used.
 ====
 
 The full list of HTTP status codes is documented http://www.ietf.org/assignments/http-status-codes/http-status-codes.xml[here^].

--- a/guide/src/main/asciidoc/statuscodes.adoc
+++ b/guide/src/main/asciidoc/statuscodes.adoc
@@ -1,16 +1,73 @@
 [[status-codes]]
 == Status codes
 
-The full list of HTTP status codes is documented http://www.ietf.org/assignments/http-status-codes/http-status-codes.xml[here^].
 
-In order to conform to the REST uniform service contract, REST services should stick to this reduced list of status codes.
+[[status-codes-by-method]]
+=== Overview
+
+[rule, stat-codes]
+.Use appropriate HTTP status codes
+====
+The HTTP response status code SHOULD be returned that best describes the outcome of the treatment of the request.
+
+Below table list most common combinations of a status code for each HTTP method, though may not be exhaustive. Combinations explicitly excluded ( `-`) SHOULD NOT be used.
+====
+
+The full list of HTTP status codes is documented http://www.ietf.org/assignments/http-status-codes/http-status-codes.xml[here^].
 
 http://for-get.github.io/http-decision-diagram/httpdd.fsm.html[This HTTP status codes chart] (takes a while to load) shows a decision tree to determine the usage of the correct HTTP status code.
 
-=== 1xx  Informational
+[cols="3,1,1,2,1,1,1,1", options="header"]
+|===
+|Code
+|GET
+|HEAD
+|PUT
+|POST
+|PATCH
+|DELETE
+|OPTIONS
+
+|<<http-200,200 OK>>
+|X
+|X
+|X
+|X (controller only)
+|X
+|X
+|X
+
+ |<<http-201,201 Created>>	|-	|-	|X (creation only) |X	|-	|-	|-
+ |<<http-202,202 Accepted>>	|-	|-	|-	|X	|-	|-	|X
+ |<<http-204,204 No Content>>	|-	|X	|X	|X	|X	|X	|-
+  |<<http-301,301 Moved Permanently>> |X	|X	|X	|X	|X	|X	|X
+  |<<http-303,303 See Other>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-304,304 Not Modified>>	|X	|X	|-	|-	|-	|-	|-
+  |<<http-307,307 Temporary Redirect>> 	|X	|X	|X	|X	|X	|X	|X
+  |<<http-400,400 Bad Request>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-401,401 Unauthorized>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-403,403 Forbidden>>	|X	|X	|X	|X	|X	|X	|X
+ |<<http-404,404 Not Found>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-405,405 Method Not Allowed>>	|X	|X	|X	|X	|X	|X	|-
+  |<<http-406,406 Not Acceptable>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-409,409 Conflict>> 	|-	|-	|X	|X	|X	|X	|-
+  |<<http-412,412 Precondition Failed>> 	|-	|-	|X	|X	|X	|X	|-
+  |<<http-413,413 Payload Too Large	>>|-	|-	|X	|X	|X	|-	|-
+  |<<http-415,415 Unsupported Media Type>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-429,429 Too Many Requests>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-500,500 Internal Server Error>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-502,502 Bad Gateway>>	|X	|X	|X	|X	|X	|X	|X
+  |<<http-503,503 Service Unavailable>> 	|X	|X	|X	|X	|X	|X	|X
+
+
+|===
+
+=== List of status codes
+
+==== 1xx  Informational
 Request received, continuing process.
 
-=== 2xx Success
+==== 2xx Success
 The action was successfully received, understood, and accepted.
 
 [cols="1,4,2", options="header"]
@@ -50,7 +107,7 @@ The 204 status code is usually sent out in response to a PUT, POST, PATCH or DEL
 
 |===
 
-=== 3xx Redirection
+==== 3xx Redirection
 Further action must be taken in order to complete the request.
 
 [cols="1,4,2", options="header"]
@@ -96,7 +153,7 @@ A REST API can use this status code to assign a temporary URI to the client’s 
 
 |===
 
-=== 4xx Client Error
+==== 4xx Client Error
 The request contains bad syntax or cannot be fulfilled.
 
 [cols="1,4,2", options="header"]
@@ -200,7 +257,7 @@ Responses with the 429 status code MUST NOT be stored by a cache.
 
 |===
 
-=== 5xx Server Error
+==== 5xx Server Error
 The server failed to fulfill an apparently valid request.
 [cols="1,4,1", options="header"]
 |===
@@ -229,51 +286,3 @@ The server MAY send a Retry-After header field to suggest an appropriate amount 
 <<GET,GET>>, <<HEAD,HEAD>>, <<POST,POST>>, <<PUT,PUT>>, <<PATCH,PATCH>>, <<DELETE,DELETE>>, <<OPTIONS,OPTIONS>>
 
 |===
-
-[[status-codes-by-method]]
-=== Status codes for each method
-[cols="3,1,1,2,1,1,1,1", options="header"]
-|===
-|Code
-|GET
-|HEAD
-|PUT
-|POST
-|PATCH
-|DELETE
-|OPTIONS
-
-|<<http-200,200 OK>>
-|X
-|X
-|X
-|X (controller only)
-|X
-|X
-|X
-
- |<<http-201,201 Created>>	|-	|-	|X (creation only) |X	|-	|-	|-
- |<<http-202,202 Accepted>>	|-	|-	|-	|X	|-	|-	|X
- |<<http-204,204 No Content>>	|-	|X	|X	|X	|X	|X	|-
-  |<<http-301,301 Moved Permanently>> |X	|X	|X	|X	|X	|X	|X
-  |<<http-303,303 See Other>>	|-	|-	|-	|X	|-	|-	|-
-  |<<http-304,304 Not Modified>>	|X	|X	|-	|-	|-	|-	|-
-  |<<http-307,307 Temporary Redirect>> 	|X	|X	|X	|X	|X	|X	|X
-  |<<http-400,400 Bad Request>>	|X	|X	|X	|X	|X	|X	|X
-  |<<http-401,401 Unauthorized>>	|X	|X	|X	|X	|X	|X	|X
-  |<<http-403,403 Forbidden>>	|X	|X	|X	|X	|X	|X	|X
- |<<http-404,404 Not Found>>	|X	|X	|X	|X	|X	|X	|X
-  |<<http-405,405 Method Not Allowed>>	|X	|X	|X	|X	|X	|X	|-
-  |<<http-406,406 Not Acceptable>>	|X	|X	|X	|X	|X	|X	|X
-  |<<http-409,409 Conflict>> 	|-	|-	|X	|X	|X	|X	|-
-  |<<http-412,412 Precondition Failed>> 	|-	|-	|X	|X	|X	|X	|-
-  |<<http-413,413 Payload Too Large	>>|-	|-	|X	|X	|X	|-	|-
-  |<<http-415,415 Unsupported Media Type>>	|X	|X	|X	|X	|X	|X	|X
-  |<<http-429,429 Too Many Requests>>	|X	|X	|X	|X	|X	|X	|X
-  |<<http-500,500 Internal Server Error>>	|X	|X	|X	|X	|X	|X	|X
-  |<<http-502,502 Bad Gateway>>	|X	|X	|X	|X	|X	|X	|X
-  |<<http-503,503 Service Unavailable>> 	|X	|X	|X	|X	|X	|X	|X
-
-
-|===
-


### PR DESCRIPTION
- explicit rule for http methods and status codes
- improve http method overview table
- correct 303 status code: allowed for all methods instead of only POST