### PR TITLE
Fix OpenAPI 2.0 example multi-value query param

### DIFF
--- a/guide/src/main/asciidoc/resources.adoc
+++ b/guide/src/main/asciidoc/resources.adoc
@@ -89,10 +89,12 @@ parameters:
 - name: embed
   in: query
   collectionFormat: multi
-  type: string
-  enum:
-  - employees
-  - mainAddress
+  type: array
+  items:
+    type: string
+    enum:
+    - employees
+    - mainAddress
 ```
 
 .OpenAPI 3.0 definition
@@ -100,7 +102,6 @@ parameters:
 parameters:
 - name: embed
   in: query
-  style: form
   explode: true
   schema:
     type: array


### PR DESCRIPTION
use array type for OpenAPI 2.0 example of multi-value query param
For OpenAPI 3.0, remove explicit style: form (already default)