### PR TITLE
Multi-value query param should be noun if singular

### DIFF
--- a/guide/src/main/asciidoc/resources.adoc
+++ b/guide/src/main/asciidoc/resources.adoc
@@ -73,6 +73,8 @@ Only return translatable properties in dutch.
 .Multiple values for the same query parameter
 ====
 When a single query parameter can have multiple values, the parameter SHOULD be repeated for each value.
+
+If the parameter's name is a noun, it SHOULD be singular.
 ====
 
 .Multi-valued parameter
@@ -80,36 +82,30 @@ When a single query parameter can have multiple values, the parameter SHOULD be 
 [subs=normal]
 .Request
 ```
-GET {API}/employers/93017373?embed=employees&embed=mainAddress
+GET /cars?color=black&color=blue
 ```
 
 .OpenAPI 2.0 definition
 ```YAML
 parameters:
-- name: embed
+- name: color
   in: query
   collectionFormat: multi
   type: array
   items:
     type: string
-    enum:
-    - employees
-    - mainAddress
 ```
 
 .OpenAPI 3.0 definition
 ```YAML
 parameters:
-- name: embed
+- name: color
   in: query
-  explode: true
+  # default values are OK (style: form, explode: true)
   schema:
     type: array
     items:
       type: string
-      enum:
-      - employees
-      - mainAddress
 ```
 ====
 

--- a/guide/src/main/asciidoc/resources.adoc
+++ b/guide/src/main/asciidoc/resources.adoc
@@ -101,7 +101,7 @@ parameters:
 parameters:
 - name: color
   in: query
-  # default values are OK (style: form, explode: true)
+  # defaults for style and explode properties are OK (style: form, explode: true)
   schema:
     type: array
     items:


### PR DESCRIPTION
- Multi-value query param should be singular if noun 
- don't set param properties that are already default in example OpenAPI