### PR TITLE
Allow 204 as the HTTP code for GET

### DIFF
--- a/guide/src/main/asciidoc/resources-collection.adoc
+++ b/guide/src/main/asciidoc/resources-collection.adoc
@@ -41,8 +41,6 @@ CAUTION: A collection resource, like other resources, MUST always return a JSON 
 | <<http-404,404>> | Not found | The URI provided cannot be mapped to a resource. 
 |===
 
-WARNING: <<http-204,204 No content>>  should not be used with GET.
-
 [rule, col-sort]
 .Sorting a collection
 ====
@@ -261,8 +259,6 @@ a|
 | <<http-404,404>> | Not found | The URI provided cannot be mapped to a resource. 
 ​
 |===
-
-WARNING: ​<<http-204,204 No content>>  should not be used with GET. 
 
 
 [subs=normal]

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -461,7 +461,6 @@ a|The dynamic path segment containing the identity key has a wrong data format:
 |The document resource does not exist.
 
 |===
-WARNING: ​<<http-204,204 No content>>  should not be used with GET. 
 
 
 ====

--- a/guide/src/main/asciidoc/statuscodes.adoc
+++ b/guide/src/main/asciidoc/statuscodes.adoc
@@ -39,7 +39,7 @@ http://for-get.github.io/http-decision-diagram/httpdd.fsm.html[This HTTP status 
 
  |<<http-201,201 Created>>	|-	|-	|X (creation only) |X	|-	|-	|-
  |<<http-202,202 Accepted>>	|-	|-	|-	|X	|-	|-	|X
- |<<http-204,204 No Content>>	|-	|X	|X	|X	|X	|X	|-
+ |<<http-204,204 No Content>>	|X	|X	|X	|X	|X	|X	|-
   |<<http-301,301 Moved Permanently>> |X	|X	|X	|X	|X	|X	|X
   |<<http-303,303 See Other>>	|X	|X	|X	|X	|X	|X	|X
   |<<http-304,304 Not Modified>>	|X	|X	|-	|-	|-	|-	|-


### PR DESCRIPTION
Hello,

While the text of the Belgif warns against the use of code 204 in response to GET, [the diagram it links to](https://for-get.github.io/http-decision-diagram/httpdd.fsm.html) seems to allow it.

I'd like to further  challenge this warning with a real-life example. 

One of my applications checks if a user responded to a meeting invitation by issuing a GET request. If the user responded to the invitation, the application returns or  yes or no and the timestamp. If not, I'd like to return 204 No Content as the most obvious answer.

