### PR TITLE
Don't recommend cross-API linking for child concepts

### DIFF
--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -56,9 +56,10 @@ a|
 
 A document may have _child resources_ of any type (document, collection or controller) that represent its specific subordinate concepts.
 
-When defining child resources, stick to concepts _within the same API_. An employer resource could contain child concepts as employees, debts, taxes, mandates, declarations, risks, but putting all these different concepts below a single document resource becomes unmanageable.
-In that case *prefer associations and create <<links,links>>* to other APIs from the employer resource.
+When defining child resources, stick to concepts _within the same API_. An employer resource could contain child concepts as employees, debts, taxes, mandates, declarations, risks, but putting all these different concepts in a single API becomes unmanageable.
+In that case *prefer including the parent resource's <<section-identifier, identifier>>* in the child concept's representation. However, don't include a link (URL) to a resource in a different API (see <<rule-hyp-links>>).
 
+[[section-identifier]]
 === Identifier
 
 [rule, id-choice]

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -54,10 +54,9 @@ a|
 
 *Child resources of a document*
 
-A document may have _child resources_ of any type (document, collection or controller) that represent its specific subordinate concepts.
-
-When defining child resources, stick to concepts _within the same API_. An employer resource could contain child concepts as employees, debts, taxes, mandates, declarations, risks, but putting all these different concepts in a single API becomes unmanageable.
-In that case *prefer including the parent resource's <<section-identifier, identifier>>* in the child concept's representation. However, don't include a link (URL) to a resource in a different API (see <<rule-hyp-links>>).
+A document may have _child resources_ of any type (document, collection or controller) that represent its specific subordinate concepts. When defining child resources, stick to concepts _within the same API_.
+Occasionally complex resources have so many related resources that putting all these different concepts in a single API becomes unmanageable. For example, an employer resource could link to related resources describing employees, debts, taxes, mandates, declarations, risks, etc.
+In that case, model the related resources in a separate API and link to the principal resource not by including a link (URL) across APIs (see <<rule-hyp-links>>) but just by adding the <<section-identifier, identifier>> of the principal resource in the representation. 
 
 [[section-identifier]]
 === Identifier


### PR DESCRIPTION
The recommendation contradicted (the recently updated) [hyp-links](https://www.belgif.be/specification/rest/api-guide/#rule-hyp-links) rule.