### PR TITLE
Clarify jsn-null and merge patch

### DIFF
--- a/guide/src/main/asciidoc/changelog.adoc
+++ b/guide/src/main/asciidoc/changelog.adoc
@@ -1,4 +1,7 @@
 == Changelog
+* 2024-xx-xx
+** clarify use of `null` in <<rule-jsn-null>>
+** add rule <<rule-doc-patch>> for JSON Merge Patch and illustrate use of nullable properties
 * 2024-04-05
 ** update <<rule-oas-tags>>: add new guidelines on tags (declared, style, no more than one tag on an operation)
 ** new: rule <<rule-oas-comp>> applies naming guidelines on all types of components (previously in <<rule-oas-types>> only for schemas)

--- a/guide/src/main/asciidoc/json.adoc
+++ b/guide/src/main/asciidoc/json.adoc
@@ -51,7 +51,7 @@ This is because `enterpriseNumber` is a fixed denomination (declared in  Crossro
 [subs="normal"]
 ```json
 {
-  "name": "Belgacom",
+  "name": "Proximus",
   "employerId": 93017373,
   "enterprise": {
     "enterpriseNumber": "0202239951"
@@ -63,7 +63,10 @@ This is because `enterpriseNumber` is a fixed denomination (declared in  Crossro
 [rule, jsn-null]
 .Null values
 ====
-Properties with a `null` value SHOULD be stripped from the JSON message.
+
+Properties without a value SHOULD be stripped from the JSON message, instead of having a `null` value.
+
+For properties or parameters with a specified type, OpenAPI disallows `null` values by default, unless `nullable: true` is specified.
 
 A notable exception to this rule are JSON Merge Patch requests, in which a `null` value indicates the removal of a JSON property.
 
@@ -75,7 +78,7 @@ Note that this rule doesn't apply to empty values (e.g. empty strings `""` or em
 a|[subs="normal"]
 ```json
 {
-  "name": "Belgacom",
+  "name": "Proximus",
   "employerId": 93017373,
   "enterprise": null
 }
@@ -84,7 +87,7 @@ a|[subs="normal"]
 a|[subs="normal"]
 ```json
 {
-  "name": "Belgacom",
+  "name": "Proximus",
   "employerId": 93017373
 }
 ```
@@ -97,7 +100,7 @@ a|[subs="normal"]
 a|[subs="normal"]
 ```json
 {
-  "name": "Belgacom",
+  "name": "Proximus",
   "employerId": 93017373
 }
 ```
@@ -107,7 +110,7 @@ a|[subs="normal"]
 ```json
 {
   "employerId": 93017373,
-  "name": "Belgacom"
+  "name": "Proximus"
 }
 ```
 |===

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -670,19 +670,31 @@ a|
 }
 ----
 
-|schema
-|`EmployerPatch`
+| schema
+|
 a|
+OpenAPI 3.0:
 [source,yaml]
 ----
-type: object
-properties:
-  bankrupt:
-    type: boolean  # mandatory property, shouldn't be nullable
-  bankruptDate:
-    type: string
-    format: date
-    nullable: true # optional property, use null to remove it
+EmployerPatch:
+  type: object
+  properties:
+    bankrupt:
+      type: boolean  # mandatory property, shouldn't be nullable
+    bankruptDate:
+      type: string
+      format: date
+      nullable: true # optional property, use null to remove it
+----
+OpenAPI 2.0 (from https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml]):
+
+[source,yaml]
+----
+  MergePatch:
+    description: JSON Merge Patch (RFC 7386) request body
+    type: object
+    additionalProperties: true
+    # Marker type as JSON Merge Patch requests can not be fully specified as a JSON Schema type in OpenAPI 2.0
 ----
 
 3+|Parameters

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -641,7 +641,7 @@ APIs should support both the media type of JSON merge patch `application/merge-p
 Properties that can be removed, must have `nullable: true` in the OpenAPI 3.0 schema describing the JSON Merge Patch request, which is an exception to <<rule-jsn-null>>.
 Swagger 2.0 does not allow to document the use of `null` values. Instead, a `MergePatch` marker type should be used, defined in https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml].
 
-JSON Merge Patch requests SHOULD be represented by a different schema than other document operations (create, consult or full update), because otherwise `required` properties may be absent and `null` values may be allowed.
+JSON Merge Patch requests SHOULD be represented by a different schema than other document operations (create, consult or full update), because in a JSON Merge Patch request, required properties may be absent or optional properties may be removed using a `null` value.
 ====
 
 .JSON merge patch

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -639,9 +639,9 @@ The `PATCH` message SHOULD conform to the JSON Merge Patch (https://tools.ietf.o
 APIs should support both the media type of JSON merge patch `application/merge-patch+json` as the generic `application/json` JSON media type.
 
 Properties that can be removed, must have `nullable: true` in the OpenAPI 3.0 schema describing the JSON Merge Patch request, which is an exception to <<rule-jsn-null>>.
-Swagger 2.0 does not allow to document the use of `null` values. Instead, a `MergePatch` marker type should be used, defined in https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml].
-
 JSON Merge Patch requests SHOULD be represented by a different schema than other document operations (create, consult or full update), because in a JSON Merge Patch request, required properties may be absent or optional properties may be removed using a `null` value.
+
+OpenAPI 2.0 does not allow to document the use of `null` values. Instead, a `MergePatch` marker type should be used, defined in https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml].
 ====
 
 .JSON merge patch

--- a/guide/src/main/asciidoc/resources-document.adoc
+++ b/guide/src/main/asciidoc/resources-document.adoc
@@ -625,16 +625,24 @@ a|
 [[document-partial-update]]
 ==== Partial update
 
+[rule, doc-patch]
+.JSON Merge patch
+====
 Use `PATCH` when you like to do a partial update of a document resource.
 
-The `PATCH` message MUST conform to the JSON Merge Patch (https://tools.ietf.org/html/rfc7386[RFC 7386]) specification:
+The `PATCH` message SHOULD conform to the JSON Merge Patch (https://tools.ietf.org/html/rfc7386[RFC 7386]) specification:
 
 * JSON properties in the request overwrite the ones in the previous resource state
 * properties with value `null` in the request are removed from the resource
 * properties not present in the request are preserved
 
 APIs should support both the media type of JSON merge patch `application/merge-patch+json` as the generic `application/json` JSON media type.
-As JSON Merge Patch requests can not be fully specified as an OpenAPI data type, a MergePatch marker type should be used, defined in https://github.com/belgif/openapi-common/blob/master/src/main/openapi/common/v1/common-v1.yaml[common-v1.yaml].
+
+Properties that can be removed, must have `nullable: true` in the OpenAPI 3.0 schema describing the JSON Merge Patch request, which is an exception to <<rule-jsn-null>>.
+Swagger 2.0 does not allow to document the use of `null` values. Instead, a `MergePatch` marker type should be used, defined in https://github.com/belgif/openapi-common/blob/master/src/main/swagger/common/v1/common-v1.yaml[common-v1.yaml].
+
+JSON Merge Patch requests SHOULD be represented by a different schema than other document operations (create, consult or full update), because otherwise `required` properties may be absent and `null` values may be allowed.
+====
 
 .JSON merge patch
 ====
@@ -646,13 +654,13 @@ PATCH {API}/employers/93017373[^] HTTP/1.1
 [cols="1,2,3"]
 |===
 |<<patch>>
-|/employers/{employerId}
+|`/employers/{employerId}`
 |Performs a partial update of an existing employer.
 
 3+|Request
 
 |body
-|JSON Merge Patch
+|`application/merge-patch+json` or  `application/json`
 a|
 [source,json]
 ----
@@ -660,6 +668,21 @@ a|
   "bankrupt": false,
   "bankruptDate": null
 }
+----
+
+|schema
+|`EmployerPatch`
+a|
+[source,yaml]
+----
+type: object
+properties:
+  bankrupt:
+    type: boolean  # mandatory property, shouldn't be nullable
+  bankruptDate:
+    type: string
+    format: date
+    nullable: true # optional property, use null to remove it
 ----
 
 3+|Parameters


### PR DESCRIPTION
#189 

- Create rule for merge patch (from current guidelines), recommend dedicated patch schemas
- clarify `nullable: true` in [jsn-null] rule

