### PR TITLE
Clarify use of time offsets in date-time

### DIFF
--- a/guide/src/main/asciidoc/json.adoc
+++ b/guide/src/main/asciidoc/json.adoc
@@ -114,6 +114,7 @@ a|[subs="normal"]
 
 **Dates are written in ISO 8601 full-date format: yyyy-MM-dd**
 
+Dates don't include time zone or offset information.
 See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#data-types[OpenAPI 3.0 data types^] and https://tools.ietf.org/html/rfc3339#section-5.6[RFC 3339 section 5.6^].
 
 ```json
@@ -125,7 +126,8 @@ See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#dat
 **Date/time are written in ISO 8601 date-time format: yyyy-MM-dd'T'HH:mm:ss.SSSXXX**
 
 See https://tools.ietf.org/html/draft-fge-json-schema-validation-00#section-7.3.1[JSON Schema Validation 7.3.1. date-time^] and https://tools.ietf.org/html/rfc3339#section-5.6[RFC 3339 section 5.6^].
-The fraction part for sub second precision is optional and may be of any length.
+The fraction part `.SSS` for sub-second precision is optional and may be of any length.
+The time offset relative to UTC (`XXX`) is mandatory and may be `Z` (zero) or of format `("+" / "-") time-hour ":" time-minute`.
 
 .Example UTC
 ```json
@@ -134,7 +136,7 @@ The fraction part for sub second precision is optional and may be of any length.
 }
 ```
 
-.Example with timezone
+.Example with numeric offset
 ```json
 {
   "lastModification": "2016-04-24T11:26:00+02:00"


### PR DESCRIPTION
Specify that time offsets are mandatory for `date-time` and forbidden for `date` properties.

I verified this in the JSON Schema standard and swagger-request-validator implementation.