### PR TITLE
Add referencedResourceNotFound issue type

### DIFF
--- a/guide/src/main/asciidoc/errorhandling.adoc
+++ b/guide/src/main/asciidoc/errorhandling.adoc
@@ -230,59 +230,12 @@ WARNING: `href` links to descriptions of standardized problem types will change 
 The library https://github.com/belgif/rest-problem-java[`belgif-rest-problem-java`] provides implementation support for these problem types when developing Java applications.
 
 include::problems/badRequest.adoc[leveloffset=3]
-
-[[input-validation-schema]]
-.InputValidationProblem schema definition (from https://github.com/belgif/openapi-problem/blob/master/src/main/openapi/problem/v1/problem-v1.yaml[problem-v1.yaml])
-```yaml
-InputValidationProblem:
-  type: object
-  allOf:
-  - $ref: "#/components/schemas/Problem"
-  properties:
-    issues:
-      type: array
-      items:
-        $ref: "#/components/schemas/InputValidationIssue"
-InputValidationIssue:
-  type: object
-  description: |
-    An issue detected during input validation.
-
-    `status` is usually not present.
-    `href`, if present, refers to documentation of the issue type.
-    Additional properties specific to the issue type may be present.
-  allOf:
-    - $ref: "#/components/schemas/Problem"
-  properties:
-    in:
-      type: string
-      description: The location of the invalid input
-      enum:
-        - body
-        - header
-        - path
-        - query
-    name:
-      type: string
-      description: The name of the invalid input
-    value:
-      description: The value of the erroneous input
-      # no type specified, allowing any type. This is valid in OpenAPI even though some editors may indicate an error
-```
-
-The possible `type` values used within `issues` should be documented for each API. They follow the same URN structure as problem types. It is RECOMMENDED to use `input-validation` as infix to distinguish them.
-
-`InputValidationProblem` replaces `InvalidParamProblem` previously used in this guide, which is now deprecated.
-
 include::problems/noAccessToken.adoc[leveloffset=3]
 include::problems/invalidAccessToken.adoc[leveloffset=3]
 include::problems/expiredAccessToken.adoc[leveloffset=3]
 include::problems/missingScope.adoc[leveloffset=3]
 include::problems/missingPermission.adoc[leveloffset=3]
 include::problems/resourceNotFound.adoc[leveloffset=3]
-
-The <<input-validation-schema,InputValidationProblem Schema Object>> SHOULD be used to represent this type of problems.
-
 include::problems/payloadTooLarge.adoc[leveloffset=3]
 include::problems/tooManyRequests.adoc[leveloffset=3]
 include::problems/tooManyFailedRequests.adoc[leveloffset=3]

--- a/guide/src/main/asciidoc/index.adoc
+++ b/guide/src/main/asciidoc/index.adoc
@@ -16,6 +16,7 @@
 :stylesheet: my-theme.css
 :checkedbox: pass:normal[&#10004;]
 :API: https://api.socialsecurity.be/demo/v1
+:full-guide:
 
 https://www.belgif.be[<- Belgif Home]
 

--- a/guide/src/main/asciidoc/problems/badRequest.adoc
+++ b/guide/src/main/asciidoc/problems/badRequest.adoc
@@ -1,3 +1,4 @@
+[[bad-request]]
 = Bad Request
 :nofooter:
 
@@ -11,8 +12,23 @@ The following issue types may be returned by any API:
 | Issue type | description
 
 |`urn:problem-type:belgif:input-validation:schemaViolation`| violation of the OpenAPI schema
-|`urn:problem-type:belgif:input-validation:unknownInput` | Request contains an unknown input field (see <<rule-req-valid>>)
+|`urn:problem-type:belgif:input-validation:unknownInput` a| Request contains an unknown input field
+ifdef::full-guide[]
+(see <<rule-req-valid>>)
+endif::[]
+|`urn:problem-type:belgif:input-validation:referencedResourceNotFound`| A resource referenced in the request by its identifier can't be found.
+
+ifdef::full-guide[]
+This issue type is only used for resource identifiers in header or query parameters or in the request body. For resource identifiers in the request path, a <<resource-not-found>> Problem is returned instead, with a `404` status code.
+endif::[]
 |===
+
+Other issue types may be defined as a URN in one of following formats:
+
+* `urn:problem-type:<org>:input-validation:<type>`
+* `urn:problem-type:<org>:input-validation:<api>:<type>`
+
+Issue types follow the same structure as a Problem, but without a `status` code.
 
 ```
 POST /enterprises/abc
@@ -25,6 +41,13 @@ POST /enterprises/abc
       "period": {
          "startDate": "2020-12-31",
          "endDate": "2020-01-01"
+      }
+    },
+    {
+      "ssin": "98765432109",
+      "period": {
+         "startDate": "2023-01-01",
+         "endDate": "2024-01-01"
       }
     }
   ]
@@ -64,6 +87,14 @@ Content-Type: application/problem+json
       "replacedBy": "23456789012"
     },
     {
+      "type": "urn:problem-type:belgif:input-validation:referencedResourceNotFound",
+      "title": "Referenced resource was not found.",
+      "detail": "A person with SSIN 98765432109 was not found",
+      "in": "body",
+      "name": "boardMembers[1].ssin",
+      "value": "98765432109"
+    },
+    {
       "type": "urn:problem-type:cbss:input-validation:invalidPeriod",
       "title": "Period is invalid",
       "detail": "endDate should be after startDate",
@@ -77,3 +108,48 @@ Content-Type: application/problem+json
   ]
 }
 ```
+
+ifdef::full-guide[]
+[[input-validation-schema]]
+.InputValidationProblem schema definition (from https://github.com/belgif/openapi-problem/blob/master/src/main/openapi/problem/v1/problem-v1.yaml[problem-v1.yaml])
+```yaml
+InputValidationProblem:
+  type: object
+  allOf:
+  - $ref: "#/components/schemas/Problem"
+  properties:
+    issues:
+      type: array
+      items:
+        $ref: "#/components/schemas/InputValidationIssue"
+InputValidationIssue:
+  type: object
+  description: |
+    An issue detected during input validation.
+
+    `status` is usually not present.
+    `href`, if present, refers to documentation of the issue type.
+    Additional properties specific to the issue type may be present.
+  allOf:
+    - $ref: "#/components/schemas/Problem"
+  properties:
+    in:
+      type: string
+      description: The location of the invalid input
+      enum:
+        - body
+        - header
+        - path
+        - query
+    name:
+      type: string
+      description: The name of the invalid input
+    value:
+      description: The value of the erroneous input
+      # no type specified, allowing any type. This is valid in OpenAPI even though some editors may indicate an error
+```
+
+The possible `type` values used within `issues` should be documented for each API. They follow the same URN structure as problem types. It is RECOMMENDED to use `input-validation` as infix to distinguish them.
+
+`InputValidationProblem` replaces `InvalidParamProblem` previously used in this guide, which is now deprecated.
+endif::[]

--- a/guide/src/main/asciidoc/problems/badRequest.adoc
+++ b/guide/src/main/asciidoc/problems/badRequest.adoc
@@ -28,7 +28,7 @@ Other issue types may be defined as a URN in one of following formats:
 * `urn:problem-type:<org>:input-validation:<type>`
 * `urn:problem-type:<org>:input-validation:<api>:<type>`
 
-Issue types follow the same structure as a Problem, but without a `status` code.
+Issue types follow the same structure as a Problem, but don't use the `status` or `instance` properties.
 
 ```
 POST /enterprises/abc
@@ -88,8 +88,8 @@ Content-Type: application/problem+json
     },
     {
       "type": "urn:problem-type:belgif:input-validation:referencedResourceNotFound",
-      "title": "Referenced resource was not found.",
-      "detail": "A person with SSIN 98765432109 was not found",
+      "title": "Referenced resource not found",
+      "detail": "Referenced resource boardMembers[1].ssin = '98765432109' does not exist",
       "in": "body",
       "name": "boardMembers[1].ssin",
       "value": "98765432109"

--- a/guide/src/main/asciidoc/problems/resourceNotFound.adoc
+++ b/guide/src/main/asciidoc/problems/resourceNotFound.adoc
@@ -1,10 +1,10 @@
+[[resource-not-found]]
 = Resource Not Found
 :nofooter:
 
 *Status code* 404 Not Found
 
 *Description* The requested resource cannot be found. The `detail` property reveals additional information about why the resource was not found.
-
 
 Either the resource path isn't specified in the API's OpenAPI specification.
 
@@ -47,3 +47,9 @@ Content-Type: application/problem+json
   ]
 }
 ```
+
+ifdef::full-guide[]
+Note that this problem type is only used when the resource path cannot be resolved. For resources referenced otherwise (i.e. request body, header or query parameter), <<bad-request>> is returned with a `urn:problem-type:belgif:input-validation:referencedResourceNotFound` issue type.
+
+The <<input-validation-schema,InputValidationProblem Schema Object>> SHOULD be used to represent this type of problem.
+endif::[]

--- a/guide/src/main/asciidoc/problems/resourceNotFound.adoc
+++ b/guide/src/main/asciidoc/problems/resourceNotFound.adoc
@@ -26,7 +26,7 @@ Content-Type: application/problem+json
 Either a path parameter or an optional child resource path don't resolve to an existing resource. Look for the more details in the `issues` property.
 
 ```
-GET /enterprises/0206731645
+GET /enterprises/0206731645/employees/12345678901
 
 HTTP/1.1 404 Not Found
 Content-Type: application/problem+json
@@ -41,7 +41,7 @@ Content-Type: application/problem+json
       {
         "in": "path",
         "name": "enterpriseNumber",
-        "detail": "the enterprise number 0206731645 is not assigned",
+        "detail": "The enterprise number 0206731645 is not assigned",
         "value": "0206731645"
       }
   ]

--- a/guide/src/main/asciidoc/problems/resourceNotFound.adoc
+++ b/guide/src/main/asciidoc/problems/resourceNotFound.adoc
@@ -23,9 +23,11 @@ Content-Type: application/problem+json
 }
 ```
 
-Either a path parameter or an optional child resource path don't resolve to an existing resource. Look for the more details in the `issues` property.
+Either a path parameter or an optional child resource path doesn't resolve to an existing resource. Look for more details in the `issues` property.
 
-```
+[source,role="primary",subs="attributes+"]
+.Parent resource not found
+----
 GET /enterprises/0206731645/employees/12345678901
 
 HTTP/1.1 404 Not Found
@@ -46,10 +48,59 @@ Content-Type: application/problem+json
       }
   ]
 }
-```
+----
+
+[source,role="secondary",subs="attributes+"]
+.Child resource not found
+----
+GET /enterprises/0206731645/employees/12345678901
+
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+
+{
+  "type": "urn:problem-type:belgif:resourceNotFound",
+  "href": "https://www.belgif.be/specification/rest/api-guide/problems/resourceNotFound.html",
+  "status": 404,
+  "title": "Resource not found",
+  "detail": "No resource /enterprises/0206731645/employees/12345678901 found",
+  "issues": [
+      {
+        "in": "path",
+        "name": "employeeSsin",
+        "detail": "Employee with SSIN 12345678901 of enterprise 0206731645 does not exist",
+        "value": "12345678901"
+      }
+  ]
+}
+----
+
+[source,role="secondary",subs="attributes+"]
+.Optional child singleton resource not found
+----
+GET /enterprises/0206731645/employees/12345678901/profilePicture
+
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+
+{
+  "type": "urn:problem-type:belgif:resourceNotFound",
+  "href": "https://www.belgif.be/specification/rest/api-guide/problems/resourceNotFound.html",
+  "status": 404,
+  "title": "Resource not found",
+  "detail": "No resource /enterprises/0206731645/employees/12345678901/profilePicture found",
+  "issues": [
+      {
+        "in": "path",
+        "name": "profilePicture",
+        "detail": "Employee 12345678901 of enterpise 0206731645 does not have a profile picture"
+      }
+  ]
+}
+----
 
 ifdef::full-guide[]
-Note that this problem type is only used when the resource path cannot be resolved. For resources referenced otherwise (i.e. request body, header or query parameter), <<bad-request>> is returned with a `urn:problem-type:belgif:input-validation:referencedResourceNotFound` issue type.
-
 The <<input-validation-schema,InputValidationProblem Schema Object>> SHOULD be used to represent this type of problem.
+
+Note that this problem type is only used when the resource path cannot be resolved. For resources referenced otherwise (i.e. request body, header or query parameter), <<bad-request>> is returned with a `urn:problem-type:belgif:input-validation:referencedResourceNotFound` issue type.
 endif::[]

--- a/guide/src/main/asciidoc/problems/resourceNotFound.adoc
+++ b/guide/src/main/asciidoc/problems/resourceNotFound.adoc
@@ -23,7 +23,7 @@ Content-Type: application/problem+json
 }
 ```
 
-Either the path parameters don't resolve to an existing resource. Look for the more details in the `issues` property.
+Either a path parameter or an optional child resource path don't resolve to an existing resource. Look for the more details in the `issues` property.
 
 ```
 GET /enterprises/0206731645


### PR DESCRIPTION
- Add referencedResourceNotFound issue type and explain difference with 404 resourceNotFound (see #126 )
- Add that resourceNotFound can be used for child resources (see #202)

Documentation for API implementers are hidden on the problem-specific HTMLs for API users using asciidoctor directives .

