### PR TITLE
Clarify identity of an async msg 

### DIFF
--- a/guide/src/main/asciidoc/events.adoc
+++ b/guide/src/main/asciidoc/events.adoc
@@ -39,8 +39,6 @@ The semantics, formats and bindings of the https://github.com/cloudevents/spec[C
 
 This guide extends upon the CloudEvents specification, defining an _Asynchronous Message_ to describe not only events, but any type of asynchronous message (e.g. an asynchronous request-reply exchange) using a CloudEvent-compatible format. It also specifies additional guidelines and context attributes.
 
-All functional message data SHOULD be part of an Asynchronous Message, without relying on additional protocol-specific information. Protocol-specific headers can be used for non-functional aspects like authentication and authorization, routing or tracing. Routing can be performed based on information contained in the event, but an event will not identify a specific routing destination.
-
 Asynchronous Messages contain two types of information:
 
 * context: metadata providing contextual information about the message
@@ -48,7 +46,15 @@ Asynchronous Messages contain two types of information:
 
 If using the CloudEvent structured JSON format, the data is represented by `data` (any JSON type) or `data_base64` (a binary as base64-encoded string).
 
-The context is represented by attributes that MUST follow strict https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#naming-conventions[naming conventions] and https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type-system[type system].
+All functional message data SHOULD be part of an Asynchronous Message, without relying on additional protocol-specific information. Protocol-specific headers can be used for non-functional aspects like authentication and authorization, routing or tracing. Routing can be performed based on information contained in the event, but an event SHOULD NOT identify a specific routing destination.
+
+An Asynchronous Message MUST be immutable. If a context attribute is added by an intermediary, the result is considered a new Asynchronous Message and the identifier of the message (combination of `source` and `id`) should be changed as well. Exchanging a message multiple times over different protocol bindings doesn't impact its identity.
+====
+
+.Context attributes of an asynchronous message
+[rule, async-ctxt]
+====
+The context of an Asynchronous Message is represented by attributes that MUST follow strict https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#naming-conventions[naming conventions] and https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md#type-system[type system].
 
 Following table lists context attributes standardized by the CloudEvents Specification, alongside the attributes `service`, `relatedto` and `relatedtosource` of an AsynchronousMessage defined by this guide.
 


### PR DESCRIPTION
added to async-cespec rule, create separate rule for list of context attributes