### PR TITLE
New rule: avoid sensitive data in URLs and HTTP headers

### DIFF
--- a/guide/src/main/asciidoc/resources.adoc
+++ b/guide/src/main/asciidoc/resources.adoc
@@ -125,4 +125,32 @@ include::resources-collection.adoc[leveloffset=+1]
 
 include::resources-controller.adoc[leveloffset=+1]
 
+=== Sensitive data
 
+[rule,sens-dat]
+.Sensitive Data in URLs or headers
+====
+Sensitive data SHOULD be put in a message payload instead of path, query or HTTP header parameters. Even though these parameters are encrypted during HTTPS transit, they are often stored in server and infrastructure logs, caches and browser history, which increases their exposure.
+The `Authorization` and `Cookie` HTTP headers are an exception, as they are recognized by infrastructure as sensitive and not logged.
+
+For operations that would otherwise be modeled as URLs containing sensitive data, the sensitive data SHOULD instead be put in the request payload of a POST operation.
+A verb suffix `get`, `update`, `delete` or `query` SHOULD be used for operations that would otherwise not use the POST method.
+Resource linking, caching or embedding are not possible for such URLs.
+
+For a single type of interaction with an entity (e.g. consult, update, delete or query), avoid introducing multiple API operations. Querying usually supports more parameters, so is more often sensitive.
+
+If sensitive data needs to be fully hidden from client or server applications, even in the message payload, consider alternatives like encryption or pseudonymisation.
+====
+
+|===
+| suffix |  original URL example                | safe URL example
+
+|`/get`  | `GET /persons/{sensitivePersonId}` | `POST /persons/get`
+|`/update`  | `PUT /persons/{sensitivePersonId}`
+or
+`PATCH /persons/{sensitivePersonId}` | `POST /persons/update`
+|`/delete`  | `DELETE /persons/{sensitivePersonId}` | `POST /persons/delete`
+|`/query`  | `GET /persons?sensitiveData={sensitiveData}` | `POST /persons/query`
+|_none_ | `POST /persons/{sensitivePersonId}/documents` | `POST /persons/documents`
+|_none_ | `POST /persons/{sensitivePersonId}/transferDossier` | `POST /persons/transferDossier`
+|===

--- a/guide/src/main/asciidoc/resources.adoc
+++ b/guide/src/main/asciidoc/resources.adoc
@@ -142,11 +142,11 @@ For a single type of interaction with an entity (e.g. consult, update, delete or
 If sensitive data needs to be fully hidden from client or server applications, even in the message payload, consider alternatives like encryption or pseudonymisation.
 ====
 
-[cols="3*a"]
+[cols="3*a", cols="1,3,3"]
 |===
 | suffix |  original URL example                | safe URL example
 
-|`/get`  a| `GET /persons/{sensitivePersonId}` | `POST /persons/get`
+|`/get`  | `GET /persons/{sensitivePersonId}` | `POST /persons/get`
 |`/update`  | `PUT /persons/{sensitivePersonId}` +
 `PATCH /persons/{sensitivePersonId}` | `POST /persons/update`
 |`/delete`  | `DELETE /persons/{sensitivePersonId}` | `POST /persons/delete`

--- a/guide/src/main/asciidoc/resources.adoc
+++ b/guide/src/main/asciidoc/resources.adoc
@@ -139,18 +139,18 @@ Resource linking, caching or embedding are not possible for such URLs.
 
 For a single type of interaction with an entity (e.g. consult, update, delete or query), avoid introducing multiple API operations. Querying usually supports more parameters, so is more often sensitive.
 
-If sensitive data needs to be fully hidden from client or server applications, even in the message payload, consider alternatives like encryption or pseudonymisation.
+If sensitive data needs to be fully hidden from middleboxes, clients or servers, even in the message payload, consider alternatives like end-to-end encryption or pseudonymization.
 ====
 
 [cols="3*a", cols="1,3,3"]
 |===
 | suffix |  original URL example                | safe URL example
 
-|`/get`  | `GET /persons/{sensitivePersonId}` | `POST /persons/get`
-|`/update`  | `PUT /persons/{sensitivePersonId}` +
-`PATCH /persons/{sensitivePersonId}` | `POST /persons/update`
-|`/delete`  | `DELETE /persons/{sensitivePersonId}` | `POST /persons/delete`
-|`/query`  | `GET /persons?sensitiveData={sensitiveData}` | `POST /persons/query`
-|_none_ | `POST /persons/{sensitivePersonId}/documents` | `POST /persons/documents`
-|_none_ | `POST /persons/{sensitivePersonId}/transferDossier` | `POST /persons/transferDossier`
+|`/get`  | `GET /accounts/{emailAddress}` | `POST /accounts/get`
+|`/update`  | `PUT /accounts/{emailAddress}` +
+`PATCH /accounts/{emailAddress}` | `POST /accounts/update`
+|`/delete`  | `DELETE /accounts/{emailAddress}` | `POST /accounts/delete`
+|`/query`  | `GET /documents?createdBy={emailAddress}` | `POST /documents/query`
+|_none_ | `POST /accounts/{emailAddress}/profilePictures` | `POST /accounts/profilePictures`
+|_none_ | `POST /accounts/{emailAddress}/deactivate` | `POST /accounts/deactivate`
 |===

--- a/guide/src/main/asciidoc/resources.adoc
+++ b/guide/src/main/asciidoc/resources.adoc
@@ -142,12 +142,12 @@ For a single type of interaction with an entity (e.g. consult, update, delete or
 If sensitive data needs to be fully hidden from client or server applications, even in the message payload, consider alternatives like encryption or pseudonymisation.
 ====
 
+[cols="3*a"]
 |===
 | suffix |  original URL example                | safe URL example
 
-|`/get`  | `GET /persons/{sensitivePersonId}` | `POST /persons/get`
-|`/update`  | `PUT /persons/{sensitivePersonId}`
-or
+|`/get`  a| `GET /persons/{sensitivePersonId}` | `POST /persons/get`
+|`/update`  | `PUT /persons/{sensitivePersonId}` +
 `PATCH /persons/{sensitivePersonId}` | `POST /persons/update`
 |`/delete`  | `DELETE /persons/{sensitivePersonId}` | `POST /persons/delete`
 |`/query`  | `GET /persons?sensitiveData={sensitiveData}` | `POST /persons/query`


### PR DESCRIPTION
See #240 

To do:
* guideline for search/query operation (and paging params), and align with it
* review location of the rule in the guide
* go through examples in the guide where we use sensitive date in URL parameters