### PR TITLE
Align MUST/SHOULD with RFC, align with validator and consistent oneOf discriminator

### DIFF
--- a/guide/src/main/asciidoc/api.adoc
+++ b/guide/src/main/asciidoc/api.adoc
@@ -25,12 +25,14 @@ Compare an API to the concept of https://www.informit.com/articles/article.aspx?
 [rule, uri-format]
 .API format
 ====
-*URI =* `https://`[green]#_host_#`/`[green]#_pathPrefix_#`/`[green]#_apiName_#`/v`[green]#_majorVersion_#`/`[green]#_resources_#
+The URLs of a REST API SHOULD have the following structure:
+
+`https://`[green]#_host_#`/`[green]#_pathPrefix_#`/`[green]#_apiName_#`/v`[green]#_majorVersion_#`/`[green]#_resources_#
 
 [gray]#_example:_ \https://api.socialsecurity.be/REST/employerProfile/v1/profiles#
 
 `https://`:: Services are at least secured on transport level using a one-way TLS connection. The implicit port is 443.
-host:: Hostname is determined by the environment where the service is deployed
+host:: Hostname is determined by the environment where the API is deployed
 pathPrefix:: Optional path prefix to discriminate between REST APIs and other resources on the same host. [gray]#(example: /REST)#
 apiName:: Name of the API that groups a functional consistent set of resources. The API name consists of one or multiple _path segments_ and SHOULD be written in lowerCamelCase [gray]#(example: /referenceData/geography)#.
 majorVersion:: Major version numbers are integers and start at 1. See <<API versioning>>.

--- a/guide/src/main/asciidoc/api_specifications.adoc
+++ b/guide/src/main/asciidoc/api_specifications.adoc
@@ -205,6 +205,7 @@ OpenAPI authors MUST specify the `required` property on a `requestBody` explicit
 ```
 ====
 
+[rule, sec-req]
 .Security requirements
 ====
 The `security` field defined at the root level of the OpenAPI entry document, or on an operation object, can be used to specify security requirements for interactions with the API.

--- a/guide/src/main/asciidoc/api_specifications.adoc
+++ b/guide/src/main/asciidoc/api_specifications.adoc
@@ -236,7 +236,8 @@ components:
           scopes:
             'scope:organization:myapi:consult': this scope allows to consult all data
             'scope:organization:myapi:update': this scope allows to update all data
-````
+```
+====
 
 [rule, gen-header]
 .General HTTP headers
@@ -638,12 +639,13 @@ The `allOf` JSON Schema keyword expresses that a value must be valid against *al
 For `object` types, it can be used to model an inheritance relationship between schemas. For code generation, the first subschema that's a reference (`$ref`) is considered the parent.
 Subschemas in an `allOf` SHOULD NOT declare the same properties, because this will lead to problems for code generation tools.
 
-To model polymorphism, the `discriminator` keyword on a parent schema designates a property used to resolve the child schema against which the object will be validated:
+To model polymorphism, the `discriminator` keyword on a parent schema designates a property that determines the child schema used for validation. The property used as discriminator (i.e. value of `propertyName`) SHOULD be specified by the parent schema and listed as `required`. Objects with discriminator values that do not resolve to a child schema, are rejected during validation.
+====
 
-* The property used as discriminator (i.e. value of `propertyName`) SHOULD be specified by the parent schema and listed as `required`.
-* It is RECOMMENDED to provide an explicit `mapping` of discriminator values to schemas, using the URI-reference syntax (e.g. `"#/components/schemas/Child"`).
-
-Objects with discriminator values that do not resolve to a child schema, are rejected during validation.
+.Discriminator mapping
+[rule, sch-discr]
+====
+The URI-reference syntax (e.g. `"#/components/schemas/Child"`) SHOULD be used to provide an explicit `mapping` of discriminator values to schemas.
 ====
 
 Using schema names in discriminator `mapping` instead of URI-references is discouraged because it leads to implementation-specific behavior (as described in https://spec.openapis.org/oas/v3.0.4#options-for-mapping-values-to-schemas[these] https://spec.openapis.org/oas/v3.0.4#resolving-implicit-connections[two] sections of the OpenAPI specification).
@@ -814,12 +816,7 @@ However, many uses of `oneOf` result in incompatibility problems with code gener
 * subschemas with an `enum` of the same simple `type` (i.e. no `array` or `object`)
 * subschemas of `type: object`, when a `discriminator` is also defined. Unlike `allOf`-style polymorphism (<<rule-sch-allof>>), properties SHOULD only be defined within the subschemas.
 
-When using `oneOf` in combination with a `discriminator`:
-
-* an explicit `mapping` of discriminator values to subschemas is RECOMMENDED, using the URI-reference syntax (e.g. `"#/components/schemas/FirstOption"`)
-* the property used as discriminator (i.e. value of `propertyName`) SHOULD be specified by each `oneOf` subschema, and listed as `required`.
-
-Objects with discriminator values that do not resolve to a subschema, are rejected during validation.
+When using `oneOf` in combination with a `discriminator`, the property used as discriminator (i.e. value of `propertyName`) SHOULD be specified by each `oneOf` subschema, and listed as `required`. The discriminator `mapping` SHOULD include each of the `oneOf` subschemas. Objects with discriminator values that do not resolve to a subschema, are rejected during validation.
 ====
 
 Examples below were tested with openapi-generator's https://openapi-generator.tech/docs/generators/java/[Java] and https://openapi-generator.tech/docs/generators/spring/[Spring code generation].

--- a/guide/src/main/asciidoc/api_specifications.adoc
+++ b/guide/src/main/asciidoc/api_specifications.adoc
@@ -210,7 +210,7 @@ OpenAPI authors MUST specify the `required` property on a `requestBody` explicit
 ====
 The `security` field defined at the root level of the OpenAPI entry document, or on an operation object, can be used to specify security requirements for interactions with the API.
 
-Each property name under `security` MUST correspond to a security scheme components (in `#/components/securitySchemes`). If the security scheme is of type `oauth2` or `openIdConnect`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope.
+Each property name under `security` MUST correspond to a security scheme defined in `#/components/securitySchemes` in the entry OpenAPI document. If the security scheme is of type `oauth2` or `openIdConnect`, the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope.
 For `oauth2` security schemes, the scope names in the security requirement MUST correspond to one of the `scopes` values in one of the OAuth flows of the corresponding security scheme component.
 ====
 
@@ -224,7 +224,7 @@ security:   # root-level security requirement is applied to all operations unles
     - 'scope:organization:myapi:update'   # scope name in at least one of the flows of the securityScheme
 components:
   securitySchemes:
-    Oauth:
+    Oauth: # the name of the securityScheme component
       type: oauth2
       flows:
         authorizationCode:

--- a/guide/src/main/asciidoc/api_specifications.adoc
+++ b/guide/src/main/asciidoc/api_specifications.adoc
@@ -184,7 +184,7 @@ Code generators use it to generate method names and generally take care of trans
 [rule, opbody-req]
 .Required request payload
 ====
-Request payloads are optional by default in OpenAPIn even though they usually need to be required. It is most of the time an omission when this default isn't changed.
+Request payloads are optional by default in OpenAPI, even though they usually need to be required. It is most of the time an omission when this default isn't changed.
 
 OpenAPI authors MUST specify the `required` property on a `requestBody` explicitly, to avoid any ambiguity.
 ====

--- a/guide/src/main/asciidoc/api_specifications.adoc
+++ b/guide/src/main/asciidoc/api_specifications.adoc
@@ -210,8 +210,8 @@ OpenAPI authors MUST specify the `required` property on a `requestBody` explicit
 ====
 The `security` field defined at the root level of the OpenAPI entry document, or on an operation object, can be used to specify security requirements for interactions with the API.
 
-Each property name under `security` MUST correspond to a security scheme components (in `#/components/securitySchemes`). If the security scheme is of type "oauth2" or "openIdConnect", then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope.
-The scope names MUST correspond to one of the `scopes` values in one of the OAuth flows the corresponding security scheme component.
+Each property name under `security` MUST correspond to a security scheme components (in `#/components/securitySchemes`). If the security scheme is of type `oauth2` or `openIdConnect`, then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope.
+For `oauth2` security schemes, the scope names in the security requirement MUST correspond to one of the `scopes` values in one of the OAuth flows of the corresponding security scheme component.
 ====
 
 .OAuth2 security requirements
@@ -219,8 +219,9 @@ The scope names MUST correspond to one of the `scopes` values in one of the OAut
 ```yaml
 security:   # root-level security requirement is applied to all operations unless overridden
   - Oauth:  # the name of the securityScheme component
-    - 'scope:organisation:myapi:consult'  # scope name in at least one of the flows of the securityScheme
-    - 'scope:organisation:myapi:update'
+    - 'scope:organization:myapi:consult'  # scope name in at least one of the flows of the securityScheme
+  - Oauth:  # the name of the securityScheme component
+    - 'scope:organization:myapi:update'   # scope name in at least one of the flows of the securityScheme
 components:
   securitySchemes:
     Oauth:

--- a/guide/src/main/asciidoc/api_specifications.adoc
+++ b/guide/src/main/asciidoc/api_specifications.adoc
@@ -60,7 +60,7 @@ Alongside the definitions of allowed interactions (operations, schemas, ...), su
 ====
 Free-text documentation can be added throughout an OpenAPI:
 
-* General documentation for the whole API can be provided in the OpenAPI's `info` object, like `title` (MANDATORY), `contact` and `description`
+* General documentation for the whole API can be provided in the OpenAPI's `info` object, like `title` (REQUIRED), `contact` and `description`
 * The `summary` property SHOULD be present on each operation providing a short functional description. When using OpenAPI visualization tools like SwaggerUI, it is displayed in the overview of all operations.
 * The `description` property on various definitions MAY be used to provide longer descriptions
 ** All `description` properties support https://commonmark.org/help/[CommonMark Markdown format] for rich text formatting.
@@ -181,6 +181,63 @@ Code generators use it to generate method names and generally take care of trans
 ```
 ====
 
+[rule, opbody-req]
+.Required request payload
+====
+Request payloads are optional by default in OpenAPIn even though they usually need to be required. It is most of the time an omission when this default isn't changed.
+
+OpenAPI authors MUST specify the `required` property on a `requestBody` explicitly, to avoid any ambiguity.
+====
+
+.Required request payload
+====
+```yaml
+/documents:
+  post:
+    summary: Create a new document
+    operationId: createDocument
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Document"
+      required: true
+```
+====
+
+.Security requirements
+====
+The `security` field defined at the root level of the OpenAPI entry document, or on an operation object, can be used to specify security requirements for interactions with the API.
+
+Each property name under `security` MUST correspond to a security scheme components (in `#/components/securitySchemes`). If the security scheme is of type "oauth2" or "openIdConnect", then the value is a list of scope names required for the execution, and the list MAY be empty if authorization does not require a specified scope.
+The scope names MUST correspond to one of the `scopes` values in one of the OAuth flows the corresponding security scheme component.
+====
+
+.OAuth2 security requirements
+====
+```yaml
+security:   # root-level security requirement is applied to all operations unless overridden
+  - Oauth:  # the name of the securityScheme component
+    - 'scope:organisation:myapi:consult'  # scope name in at least one of the flows of the securityScheme
+    - 'scope:organisation:myapi:update'
+components:
+  securitySchemes:
+    Oauth:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: 'https://oauth.example.org/authorize'
+          tokenUrl: 'https://oauth.example.org/token'
+          scopes:
+            'scope:organization:myapi:consult': this scope allows to consult all data
+            'scope:organization:myapi:update': this scope allows to update all data
+        clientCredentials:
+          tokenUrl: 'https://oauth.example.org/token'
+          scopes:
+            'scope:organization:myapi:consult': this scope allows to consult all data
+            'scope:organization:myapi:update': this scope allows to update all data
+````
+
 [rule, gen-header]
 .General HTTP headers
 ====
@@ -246,6 +303,8 @@ Note that these are exceptions to the rule that API resource URLs shouldn't have
 ====
 [[default-values,default values]]
 Absent optional properties in a request are set by the API provider to their `default` value if one is specified in the OpenAPI description.
+
+Default values MUST be schema-valid.
 ====
 
 [rule, path-param]

--- a/guide/src/main/asciidoc/errorhandling.adoc
+++ b/guide/src/main/asciidoc/errorhandling.adoc
@@ -70,7 +70,7 @@ The Problem Details response body MAY be absent when the HTTP status code itself
 This guide applies following additional restrictions on the Problem Details structure:
 
 * `type` and `instance` SHOULD be specified as absolute URIs in order to avoid issues when resolving relative URIs (see <<links>>)
-* The `type` property, a stable identifier for the type of problem, is MANDATORY instead of optional
+* The `type` property, a stable identifier for the type of problem, is REQUIRED instead of optional
 * a new optional `href` property SHOULD be used to provide a URI to human-readable documentation on the problem type instead of dereferencing the `type` value
 ====
 

--- a/guide/src/main/asciidoc/introduction.adoc
+++ b/guide/src/main/asciidoc/introduction.adoc
@@ -65,3 +65,7 @@ You may obtain a copy of the License at
    See the License for the specific language governing permissions and
    limitations under the License.
 ```
+
+*Conformance*
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in https://www.rfc-editor.org/info/bcp14[BCP 14] https://www.rfc-editor.org/rfc/rfc2119[[RFC2119]] https://www.rfc-editor.org/rfc/rfc8174[[RFC8174]] when, and only when, they appear in all capitals, as shown here.

--- a/guide/src/main/asciidoc/resources-collection.adoc
+++ b/guide/src/main/asciidoc/resources-collection.adoc
@@ -291,10 +291,10 @@ Take into account the considerations http://zalando.github.io/restful-api-guidel
 
 |===
 
-|`next` | MANDATORY (except for the last page) | hyperlink to the next page
+|`next` | REQUIRED (except for the last page) | hyperlink to the next page
 |`prev` | OPTIONAL | hyperlink to the previous page
 |`pageSize` | RECOMMENDED | Maximum number of items per page. For the last page, its value should be independent of the number of actually returned items.
-| `page` |MANDATORY (offset-based); N/A (cursor-based) | index of the current page of items, should be 1-based (the default and first page is 1)
+| `page` |REQUIRED (offset-based); N/A (cursor-based) | index of the current page of items, should be 1-based (the default and first page is 1)
 | `first` | OPTIONAL | hyperlink to the first page
 | `last` | OPTIONAL | hyperlink to the last page
 | `total` | OPTIONAL | Total number of items across all pages. If query parameters are used to filter the result set, this is the total of the collection result set, not of the entire collection.
@@ -308,7 +308,7 @@ The names of the properties with hyperlink values and the `items` property are d
 |===
 
 | `pageSize` | OPTIONAL |  maximum number of items per page desired by client; must have a default value if absent.
-| `page` | MANDATORY with default value 1 (offset-based); N/A (cursor-based) | the index of page to be retrieved
+| `page` | REQUIRED with default value 1 (offset-based); N/A (cursor-based) | the index of page to be retrieved
 
 |===
 


### PR DESCRIPTION
Align rules with what's checked in the validator:
* Add rule "Required request payload"
* Add rule "Security requirements"

More consistent use of RFC2119 keywords like MUST/REQUIRED, SHOULD/RECOMMENDED:
* Replace MANDATORY by REQUIRED.
* Add reference to the RFC.

Split off new "Discriminator mapping" rule from sch-allof and sch-oneof to avoid duplication.
Somewhat related change: in oneOf-style discriminator, the mappings should include all oneOf subschemas